### PR TITLE
Offer user to attempt login to ECR before running

### DIFF
--- a/bin/docker_login.sh
+++ b/bin/docker_login.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set +e
+
+# List of shell files which have useful functions within
+shell_files=(
+  "${HOME}"/.bash_profile
+  "${HOME}"/.bashrc
+  "${HOME}"/.companies_house_config/easy_aws_docker_login.sh
+)
+
+ecr_repo_pattern="([[:digit:]]+)\.dkr\.ecr\.([^.]+)\.amazonaws.com"
+
+# Source all the user's shell files
+for shell_file in "${shell_files[@]}"; do
+  if [[ -f "${shell_file}" ]]; then
+    # shellcheck disable=SC1090
+    . "${shell_file}"
+  fi
+done
+
+command -v l_aws >/dev/null 2>&1 || function l_aws() {
+  while getopts 'p:' opt; do
+    case "${opt}" in
+    p) profile="${OPTARG}" ;;
+    *) printf -- 'Unknown arg\n' >&2 ;;
+    esac
+  done
+
+  : "${profile:?profile required}"
+
+  aws sso login --profile "${profile}"
+}
+
+repository_urls=("$@")
+
+profile_mapping_file="$(mktemp)"
+trap 'rm "${profile_mapping_file}"' EXIT
+
+aws configure list-profiles --output text |
+  while read -r profile; do
+    sso_account_id="$(aws configure get sso_account_id --profile "${profile}")"
+
+    if [[ -n "${sso_account_id}" ]]; then
+      while : ""; do
+        account_id="$(aws sts get-caller-identity --query Account --output text --profile "${profile}")"
+
+        if [[ -n "${account_id}" ]]; then
+          region="$(aws configure get region --profile "${profile}")"
+          printf -- '%s %s %s\n' "${account_id}" "${region}" "${profile}" >>"${profile_mapping_file}"
+          break
+        else
+          l_aws -p "${profile}"
+        fi
+      done
+    else
+      account_id="$(aws sts get-caller-identity --query Account --output text --profile "${profile}")"
+
+      if [[ -n "${account_id}" ]]; then
+        region="$(aws configure get region --profile "${profile}")"
+        printf -- '%s %s %s\n' "${account_id}" "${region}" "${profile}" >>"${profile_mapping_file}"
+      else
+        printf -- 'Cannot determine account id for profile %s are the keys correct?\n' "${profile}" >&2
+      fi
+
+    fi
+  done
+
+for required_repo in "${repository_urls[@]}"; do
+  if [[ "${required_repo}" =~ ${ecr_repo_pattern} ]]; then
+    required_account="${BASH_REMATCH[1]}"
+    required_region="${BASH_REMATCH[2]}"
+
+    profile="$(grep -E "^${required_account}\s${required_region}" "${profile_mapping_file}" | head -n1 | cut -d' ' -f3)"
+
+    while : ""; do
+      if [[ -n "${profile}" ]]; then
+        printf -- 'Logging into %s\n' "${required_repo}"
+
+        aws ecr get-login-password --profile "${profile}" --region "${required_region}" |
+          docker login --username AWS --password-stdin "${required_repo}"
+        break
+      else
+        profile="$(grep -E "^${required_account}\s" | head -n1 | cut -d' ' -f3)"
+      fi
+    done
+  fi
+done

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     },
     "hooks": {
       "init": "./lib/hooks/init.js",
+      "ensure-ecr-logged-in": "./lib/hooks/ensure-ecr-logged-in.js",
       "generate-runnable-docker-compose": "./lib/hooks/generate-runnable-docker-compose.js",
       "generate-development-docker-compose": "./lib/hooks/generate-development-docker-compose.js"
     },

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -38,6 +38,16 @@ export default class Up extends Command {
     }
 
     async run (): Promise<any> {
+        try {
+            await this.config.runHook("ensure-ecr-logged-in", {});
+        } catch (error) {
+            return this.error(error as Error, {
+                suggestions: [
+                    "Login to ECR manually and try again"
+                ]
+            });
+        }
+
         cli.action.start(`Running chs-dev environment: ${basename(this.chsDevConfig.projectPath)}`);
         await this.dockerCompose.up();
 

--- a/src/helpers/config-loader.ts
+++ b/src/helpers/config-loader.ts
@@ -1,9 +1,10 @@
 import { existsSync, readFileSync } from "fs";
-import { join } from "path";
+import { basename, join } from "path";
 import yaml from "yaml";
 import Config from "../model/Config.js";
 
 const fileVarRegExp = /^file:\/\/(.+)$/;
+const DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD = 8;
 
 /**
  * Loads the configuration from the project root. When project does not contain
@@ -14,22 +15,38 @@ export const load: () => Config = () => {
     const projectPath = process.cwd();
     const confFile = join(projectPath, "chs-dev/config.yaml");
 
+    let config: Partial<Config> = {};
+
     if (!existsSync(confFile)) {
-        return {
+        config = {
             env: {},
-            projectPath
+            projectPath,
+            projectName: basename(projectPath),
+            authenticatedRepositories: []
         };
 
     } else {
         const rawConfiguration = readFileSync(join(confFile)).toString("utf8");
 
-        const configuration = yaml.parse(rawConfiguration);
+        const projectConfiguration = yaml.parse(rawConfiguration);
 
-        return {
-            env: parseEnv(configuration.env) || {},
-            projectPath
+        config = {
+            env: parseEnv(projectConfiguration.env) || {},
+            projectPath,
+            projectName: basename(projectPath),
+            authenticatedRepositories: projectConfiguration.authed_repositories || [],
+            performEcrLoginHoursThreshold: projectConfiguration.authed_repositories && projectConfiguration.ecr_login_threshold_hours ? projectConfiguration.ecr_login_threshold_hours : undefined
         };
     }
+
+    if (config.authenticatedRepositories && config.authenticatedRepositories.length > 0 && !config.performEcrLoginHoursThreshold) {
+        config = {
+            ...config,
+            performEcrLoginHoursThreshold: DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD
+        };
+    }
+
+    return config as Config;
 };
 
 const parseEnv = (env: Record<string, string> | undefined) => {

--- a/src/helpers/spawn-promise.ts
+++ b/src/helpers/spawn-promise.ts
@@ -1,0 +1,65 @@
+import childProcess, { SpawnOptions } from "child_process";
+import { LogHandler } from "../run/logs/logs-handler.js";
+
+export type SpawnPromiseOptions = {
+    logHandler: LogHandler;
+
+    stderrLogHandler?: LogHandler;
+
+    spawnOptions?: SpawnOptions;
+
+    acceptableExitCodes?: number[];
+}
+
+/**
+ * Runs spawn process within a Promise and attaches the supplied log handlers
+ * to the appropriate streams.
+ * @param command: string - executable to spawn
+ * @param args: string[] - list of arguments to pass to the executable
+ * @param options: SpawnPromiseOptions - Configuration providing extra
+ *          properties to the function
+ * @returns promise detailing the result of the spawned process. If the
+ *          exit code equals one of the ones provided in `acceptableExitCodes`
+ *          then resolves otherwise will reject.
+ */
+export const spawn = (
+    command: string,
+    args: string[],
+    {
+        logHandler,
+        spawnOptions,
+        stderrLogHandler,
+        acceptableExitCodes
+    }: SpawnPromiseOptions
+): Promise<void> => {
+    if (!stderrLogHandler) {
+        stderrLogHandler = logHandler;
+    }
+
+    if (!acceptableExitCodes) {
+        acceptableExitCodes = [0];
+    }
+
+    return new Promise((resolve, reject) => {
+        const process = childProcess.spawn(
+            command,
+            args,
+            spawnOptions
+        );
+
+        process.stdout.on("data", data => logHandler.handle(data));
+        process.stderr.on("data", data => stderrLogHandler.handle(data));
+
+        process.once("exit", (code: number) => {
+            if (acceptableExitCodes.includes(code)) {
+                return resolve();
+            }
+
+            return reject(code);
+        });
+
+        process.once("error", (error) => {
+            reject(error);
+        });
+    });
+};

--- a/src/helpers/time-within-threshold.ts
+++ b/src/helpers/time-within-threshold.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "fs";
+
+export enum ThresholdUnit {
+    MINUTES = 1000 * 60,
+    HOURS = 1000 * 60 * 60,
+    DAYS = 1000 * 60 * 60 * 24
+}
+
+/**
+ * Determines whether the ISO date stored within the file date supplied is
+ * within the supplied threshold of the date within file `comparisonFile`
+ * @param comparisonFile: string - path to file containing ISO date to compare
+ *              the executionTime to
+ * @param executionTime: Date | number - value to compare to the value in file
+ *              which must be within the defined threshold
+ * @param thresholdValue: number - number of units which define the acceptable
+ *              theshold
+ * @param thresholdUnit: ThresholdUnit - The unit of the threshold being tested
+ * @returns boolean indicating whether exectutionTime is within the threshold
+ * supplied
+ */
+export const timeWithinThreshold = (
+    comparisonFile: string,
+    executionTime: Date | number,
+    thresholdValue: number,
+    thresholdUnit: ThresholdUnit
+) => {
+    let withinThreshold: boolean = true;
+
+    const lastRun = readFileSync(comparisonFile).toString("utf8");
+
+    if (executionTime instanceof Date) {
+        executionTime = executionTime.getTime();
+    }
+
+    const difference = executionTime - Date.parse(lastRun);
+
+    const numberOfUnitsLapsed = Math.floor(
+        difference / thresholdUnit
+    );
+
+    if (numberOfUnitsLapsed >= thresholdValue) {
+        withinThreshold = false;
+    }
+
+    return withinThreshold;
+};

--- a/src/hooks/ensure-ecr-logged-in.ts
+++ b/src/hooks/ensure-ecr-logged-in.ts
@@ -1,0 +1,76 @@
+import { Hook } from "@oclif/core";
+import confirm from "@inquirer/confirm";
+import { DockerEcrLogin } from "../run/docker-ecr-login.js";
+import loadConfig from "../helpers/config-loader.js";
+import { existsSync, writeFileSync } from "fs";
+import { join } from "path";
+import { ThresholdUnit, timeWithinThreshold } from "../helpers/time-within-threshold.js";
+import Config from "../model/Config.js";
+
+/**
+ * Oclif hook which will offer the user to login to ECR if not logged in
+ * @param param0 contains context and config
+ */
+export const hook: Hook<"ensure-ecr-logged-in"> = async ({ config, context }) => {
+
+    const projectConfig = loadConfig();
+    const executionTime = Date.now();
+
+    if (projectConfig.authenticatedRepositories.length > 0) {
+        const lastRunTimeFile = join(config.dataDir, `${projectConfig.projectName}.prerun.last_run_time`);
+
+        const lastRuntimeExists = existsSync(lastRunTimeFile);
+
+        const runCheck = "CHS_DEV_FORCE_ECR_CHECK" in process.env || !(lastRuntimeExists && timeWithinThreshold(
+            lastRunTimeFile,
+            executionTime,
+            projectConfig.performEcrLoginHoursThreshold as number,
+            ThresholdUnit.HOURS
+        ));
+
+        if (runCheck) {
+            await attemptEcrLogin(config, projectConfig, context, lastRunTimeFile, executionTime);
+        }
+    }
+};
+
+const attemptEcrLogin = async (
+    config,
+    projectConfig: Config,
+    context,
+    lastRunTimeFile: string,
+    executionTime: number) => {
+    const runLogin = await confirm({
+        message: "Do you want to attempt to login to AWS ECR?"
+    });
+
+    if (runLogin) {
+        const dockerEcrLogin = new DockerEcrLogin(
+            config.root, projectConfig, {
+                log: console.log
+            }
+        );
+
+        let continueWithAction = true;
+
+        try {
+            await dockerEcrLogin.attemptLoginToDockerEcr();
+        } catch (error) {
+            console.error(error);
+
+            continueWithAction = await confirm({
+                message: "Was not able to login to ECR do you want to continue?"
+            });
+        }
+
+        if (!continueWithAction) {
+            context.error(new Error("not logged into AWS ECR"));
+        } else {
+            writeFileSync(
+                lastRunTimeFile,
+                new Date(executionTime).toISOString()
+            );
+        }
+
+    }
+};

--- a/src/model/Config.ts
+++ b/src/model/Config.ts
@@ -5,6 +5,11 @@
 export type Config = {
 
     /**
+     * name to refer to the project/environment
+     */
+    readonly projectName: string;
+
+    /**
      * path to the project repository
      */
     readonly projectPath: string;
@@ -15,6 +20,18 @@ export type Config = {
      * its place.
      */
     readonly env: Record<string, string>;
+
+    /**
+     * collection of Docker repositories in use by the project which require
+     * authentication.
+     */
+    readonly authenticatedRepositories: string[];
+
+    /**
+     * when supplied defines the threshold for number of hours after which to
+     * attempt ecr login
+     */
+    readonly performEcrLoginHoursThreshold?: number;
 }
 
 export default Config;

--- a/src/run/docker-ecr-login.ts
+++ b/src/run/docker-ecr-login.ts
@@ -1,0 +1,35 @@
+import { existsSync } from "fs";
+import Config from "../model/Config.js";
+import { join } from "path";
+import { spawn } from "../helpers/spawn-promise.js";
+import LogEverythingLogHandler from "./logs/LogEverythingLogHandler.js";
+import { Logger } from "./logs/logs-handler.js";
+
+export class DockerEcrLogin {
+
+    // eslint-disable-next-line no-useless-constructor
+    constructor (private readonly chsDevInstallDirectory: string, private readonly config: Config, private readonly logger: Logger) { }
+
+    attemptLoginToDockerEcr (): Promise<void> {
+        const awsConfigurationFile = join(process.env.HOME as string, ".aws/config");
+
+        if (!existsSync(awsConfigurationFile)) {
+            return Promise.reject(new Error("Does not look like AWS has been configured"));
+        }
+
+        return spawn(
+            // "/bin/bash",
+            join(this.chsDevInstallDirectory, "bin/docker_login.sh"),
+            [
+                "--",
+                ...this.config.authenticatedRepositories
+            ],
+            {
+                logHandler: new LogEverythingLogHandler(this.logger),
+                spawnOptions: {
+                    shell: "/bin/bash"
+                }
+            }
+        );
+    }
+}

--- a/src/run/logs/LogEverythingLogHandler.ts
+++ b/src/run/logs/LogEverythingLogHandler.ts
@@ -18,3 +18,5 @@ export class LogEverythingLogHandler implements LogHandler {
         }
     }
 }
+
+export default LogEverythingLogHandler;

--- a/test/commands/up.spec.ts
+++ b/test/commands/up.spec.ts
@@ -133,4 +133,18 @@ describe("Up command", () => {
         });
 
     });
+
+    it("should run the ensure ecr is logged in hook", async () => {
+        await up.run();
+
+        expect(runHookMock).toHaveBeenCalledWith("ensure-ecr-logged-in", {});
+    });
+
+    it("should not run up if ecr was not logged in successfully", async () => {
+        runHookMock.mockRejectedValue(new Error("error"));
+
+        await expect(up.run()).rejects.toEqual(expect.anything());
+
+        expect(dockerComposeUpMock).not.toHaveBeenCalled();
+    });
 });

--- a/test/helpers/config-loader.spec.ts
+++ b/test/helpers/config-loader.spec.ts
@@ -27,7 +27,7 @@ describe("load", () => {
     it("returns empty configuration when no configuration file exists", () => {
         existsSyncMock.mockReturnValue(false);
 
-        expect(load()).toEqual({ env: {}, projectPath: pwd });
+        expect(load()).toEqual({ projectName: "docker-chs", env: {}, projectPath: pwd, authenticatedRepositories: [] });
     });
 
     it("returns configuration file with environment when file exists with environment", () => {
@@ -47,7 +47,10 @@ describe("load", () => {
                 ENV_VAR_FOUR: "file://./file-two.csv",
                 ENV_VAR_FIVE: "file:///users/user/file-two",
                 ENV_VAR_SIX: "file://~/.file-not-found"
-            }
+            },
+            authed_repositories: [
+                "123456789.dkr.eu-west-2.amazonaws.com"
+            ]
         };
         readFileSyncMock.mockImplementation((path, _) => {
             if (path === join(pwd, "chs-dev/config.yaml")) {
@@ -58,6 +61,7 @@ describe("load", () => {
         });
 
         expect(load()).toEqual({
+            projectName: "docker-chs",
             env: {
                 ENV_VAR_ONE: "some_value",
                 ENV_VAR_TWO: "some_other_value",
@@ -66,7 +70,35 @@ describe("load", () => {
                 ENV_VAR_FIVE: "foo=bar",
                 ENV_VAR_SIX: "file://~/.file-not-found"
             },
-            projectPath: pwd
+            projectPath: pwd,
+            authenticatedRepositories: [
+                "123456789.dkr.eu-west-2.amazonaws.com"
+            ],
+            performEcrLoginHoursThreshold: 8
+        });
+    });
+
+    it("returns defined login threshold", () => {
+        existsSyncMock.mockReturnValue(true);
+
+        const configuration = {
+            env: {},
+            authed_repositories: [
+                "123456789.dkr.eu-west-2.amazonaws.com"
+            ],
+            ecr_login_threshold_hours: 7
+        };
+
+        readFileSyncMock.mockReturnValue(
+            Buffer.from(yaml.stringify(configuration), "utf8")
+        );
+
+        expect(load()).toEqual({
+            env: {},
+            projectPath: pwd,
+            projectName: "docker-chs",
+            authenticatedRepositories: ["123456789.dkr.eu-west-2.amazonaws.com"],
+            performEcrLoginHoursThreshold: 7
         });
     });
 });

--- a/test/helpers/spawn-promise.spec.ts
+++ b/test/helpers/spawn-promise.spec.ts
@@ -1,0 +1,167 @@
+import { expect, jest } from "@jest/globals";
+import childProcess, { SpawnOptions } from "child_process";
+import { EventEmitter, PassThrough } from "stream";
+import { spawn } from "../../src/helpers/spawn-promise";
+
+describe("spawn", () => {
+    const spawnSpy = jest.spyOn(childProcess, "spawn");
+
+    let spawnStreamMock;
+    let stdoutStreamMock;
+    let stderrStreamMock;
+
+    const logHandlerMock = {
+        handle: jest.fn()
+    };
+
+    const stderrLogHandlerMock = {
+        handle: jest.fn()
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        spawnStreamMock = new EventEmitter();
+        stdoutStreamMock = new PassThrough();
+        stderrStreamMock = new PassThrough();
+
+        spawnStreamMock.stdout = stdoutStreamMock;
+        spawnStreamMock.stderr = stderrStreamMock;
+
+        spawnSpy.mockReturnValue(spawnStreamMock as any);
+    });
+
+    const acceptableExitCodes = [0, 10, 100];
+
+    for (const acceptableCode of acceptableExitCodes) {
+
+        it(`resolves when exit acceptable code (${acceptableCode})`, async () => {
+            const spawnPromise = spawn(
+                "ls",
+                ["-la"],
+                {
+                    logHandler: logHandlerMock,
+                    acceptableExitCodes
+                }
+            );
+
+            spawnStreamMock.emit("exit", acceptableCode);
+
+            await expect(spawnPromise).resolves.toBeUndefined();
+        });
+    }
+
+    it("rejects with error code when code is not acceptable", async () => {
+        const spawnPromise = spawn(
+            "ls",
+            ["-la"],
+            {
+                logHandler: logHandlerMock,
+                acceptableExitCodes
+            }
+        );
+
+        spawnStreamMock.emit("exit", 1);
+
+        await expect(spawnPromise).rejects.toBe(1);
+    });
+
+    it("executes spawn correctly - when supplied with spawnOptions", async () => {
+        const spawnOptions: SpawnOptions = {
+            env: {
+                ENV_ONE: "yes"
+            }
+        };
+
+        const spawnPromise = spawn(
+            "ls",
+            ["-la"],
+            {
+                logHandler: logHandlerMock,
+                acceptableExitCodes,
+                spawnOptions
+            }
+        );
+
+        spawnStreamMock.emit("exit", 0);
+
+        await spawnPromise;
+
+        expect(spawnSpy).toHaveBeenCalledWith(
+            "ls",
+            ["-la"],
+            spawnOptions
+        );
+    });
+
+    it("logs stdout to handler", async () => {
+
+        const spawnPromise = spawn(
+            "ls",
+            ["-la"],
+            {
+                logHandler: logHandlerMock,
+                acceptableExitCodes
+            }
+        );
+
+        stdoutStreamMock.emit("data", "line 1\nline 2\n");
+        stdoutStreamMock.emit("data", "line 3");
+
+        spawnStreamMock.emit("exit", 0);
+
+        await spawnPromise;
+
+        expect(logHandlerMock.handle).toHaveBeenCalledTimes(2);
+        expect(logHandlerMock.handle).toHaveBeenCalledWith("line 1\nline 2\n");
+        expect(logHandlerMock.handle).toHaveBeenCalledWith("line 3");
+    });
+
+    it("logs stderr to same handler as stdout when not supplied", async () => {
+
+        const spawnPromise = spawn(
+            "ls",
+            ["-la"],
+            {
+                logHandler: logHandlerMock,
+                acceptableExitCodes
+            }
+        );
+
+        stderrStreamMock.emit("data", "line 1\nline 2\n");
+        stderrStreamMock.emit("data", "line 3");
+
+        spawnStreamMock.emit("exit", 0);
+
+        await spawnPromise;
+
+        expect(logHandlerMock.handle).toHaveBeenCalledTimes(2);
+        expect(logHandlerMock.handle).toHaveBeenCalledWith("line 1\nline 2\n");
+        expect(logHandlerMock.handle).toHaveBeenCalledWith("line 3");
+    });
+
+    it("logs stderr to stderr handler as stdout when supplied", async () => {
+
+        const spawnPromise = spawn(
+            "ls",
+            ["-la"],
+            {
+                logHandler: logHandlerMock,
+                stderrLogHandler: stderrLogHandlerMock,
+                acceptableExitCodes
+            }
+        );
+
+        stderrStreamMock.emit("data", "line 1\nline 2\n");
+        stderrStreamMock.emit("data", "line 3");
+
+        spawnStreamMock.emit("exit", 0);
+
+        await spawnPromise;
+
+        expect(logHandlerMock.handle).not.toHaveBeenCalled();
+        expect(stderrLogHandlerMock.handle).toHaveBeenCalledTimes(2);
+        expect(stderrLogHandlerMock.handle).toHaveBeenCalledWith("line 1\nline 2\n");
+        expect(stderrLogHandlerMock.handle).toHaveBeenCalledWith("line 3");
+    });
+});

--- a/test/helpers/time-within-threshold.spec.ts
+++ b/test/helpers/time-within-threshold.spec.ts
@@ -1,0 +1,83 @@
+import { expect, jest } from "@jest/globals";
+import fs from "fs";
+import { ThresholdUnit, timeWithinThreshold } from "../../src/helpers/time-within-threshold";
+
+const greaterThresholdTestCases: [string, number, string, ThresholdUnit][] = [
+    ["2024-06-02T00:00:00.000Z", 2, "DAYS", ThresholdUnit.DAYS],
+    ["2024-05-06T22:35:00.001Z", 2, "DAYS", ThresholdUnit.DAYS],
+    ["2024-05-04T22:35:00.000Z", 2, "HOURS", ThresholdUnit.HOURS],
+    ["2024-05-04T01:34:00.001Z", 2, "HOURS", ThresholdUnit.HOURS],
+    ["2024-05-04T00:35:00.000Z", 2, "HOURS", ThresholdUnit.HOURS],
+    ["2024-05-04T00:35:00.000Z", 2, "MINUTES", ThresholdUnit.MINUTES],
+    ["2024-05-04T22:36:01.000Z", 2, "MINUTES", ThresholdUnit.MINUTES],
+    ["2024-05-04T22:37:00.000Z", 2, "MINUTES", ThresholdUnit.MINUTES]
+];
+
+const lowerThresholdTestCases: [string, number, string, ThresholdUnit][] = [
+    ["2024-05-03T22:34:00.432Z", 2, "DAYS", ThresholdUnit.DAYS],
+    ["2024-05-03T22:35:00.000Z", 2, "DAYS", ThresholdUnit.DAYS],
+    ["2024-05-04T22:34:00.432Z", 2, "DAYS", ThresholdUnit.DAYS],
+    ["2024-05-05T00:34:00.432Z", 2, "DAYS", ThresholdUnit.DAYS],
+    ["2024-05-05T21:34:00.432Z", 2, "DAYS", ThresholdUnit.DAYS],
+    ["2024-05-03T22:34:00.432Z", 2, "HOURS", ThresholdUnit.HOURS],
+    ["2024-05-04T00:34:00.000Z", 2, "HOURS", ThresholdUnit.HOURS],
+    ["2024-05-03T23:34:00.432Z", 2, "HOURS", ThresholdUnit.HOURS],
+    ["2024-05-03T00:33:59.999Z", 2, "HOURS", ThresholdUnit.HOURS],
+    ["2024-05-03T22:34:00.432Z", 2, "MINUTES", ThresholdUnit.MINUTES],
+    ["2024-05-03T22:34:30.432Z", 2, "MINUTES", ThresholdUnit.MINUTES],
+    ["2024-05-03T22:35:30.432Z", 2, "MINUTES", ThresholdUnit.MINUTES],
+    ["2024-05-03T22:35:59.999Z", 2, "MINUTES", ThresholdUnit.MINUTES]
+];
+
+const runTestCases = (expectedValue: boolean, difference: string, testCases: [string, number, string, ThresholdUnit][]) => {
+    describe(`returns ${expectedValue} when ${difference}`, () => {
+        for (const [executionTime, value, unitName, unit] of testCases) {
+            it(`comparing value ${difference} ${unitName} (${executionTime}, ${value} ${unitName})`, () => {
+                expect(timeWithinThreshold(
+                    "./comparisonfile",
+                    Date.parse(executionTime as string),
+                    value as number,
+                    unit as ThresholdUnit
+                )).toBe(expectedValue);
+            });
+        }
+    });
+};
+
+describe("timeWithinThreshold", () => {
+    const readFileSyncSpy = jest.spyOn(fs, "readFileSync");
+
+    const comparisonFileValue = "2024-05-03T22:34:00.432Z";
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        readFileSyncSpy.mockReturnValue(
+            Buffer.from(comparisonFileValue, "utf8")
+        );
+    });
+
+    it("reads file supplied", () => {
+        timeWithinThreshold(
+            "./comparisonfile",
+            Date.parse("2021-01-01T09:00:00.999Z"),
+            2,
+            ThresholdUnit.DAYS
+        );
+
+        expect(readFileSyncSpy).toHaveBeenCalledWith("./comparisonfile");
+    });
+
+    it("can handle dates as input", () => {
+        expect(timeWithinThreshold(
+            "./comparisonfile",
+            new Date(Date.parse("2029-01-01T09:00:00.999Z")),
+            2,
+            ThresholdUnit.DAYS
+        )).toBe(false);
+    });
+
+    runTestCases(false, "greater", greaterThresholdTestCases);
+
+    runTestCases(true, "lower", lowerThresholdTestCases);
+});

--- a/test/hooks/ensure-ecr-logged-in.spec.ts
+++ b/test/hooks/ensure-ecr-logged-in.spec.ts
@@ -1,0 +1,271 @@
+import { expect, jest } from "@jest/globals";
+import fs from "fs";
+import confirm from "@inquirer/confirm";
+import { hook } from "../../src/hooks/ensure-ecr-logged-in";
+import { join } from "path";
+import { error } from "console";
+
+const attemptLoginToDockerEcrMock = jest.fn();
+const configLoaderMock = jest.fn();
+
+jest.mock("../../src/run/docker-ecr-login", () => {
+    return {
+        DockerEcrLogin: function () {
+            return {
+                attemptLoginToDockerEcr: attemptLoginToDockerEcrMock
+            };
+        }
+    };
+});
+
+jest.mock("../../src/helpers/config-loader", () => {
+    return () => {
+        return configLoaderMock();
+    };
+});
+
+jest.mock("@inquirer/confirm");
+
+const testTimeIsoUtc = "2024-05-01T11:00:00.000Z";
+
+const testTimeMinusHours = (hours) => {
+    const testTime = Date.parse(testTimeIsoUtc);
+
+    const hoursInMillis = 60 * 60 * 1000 * hours;
+
+    return new Date(testTime - hoursInMillis).toUTCString();
+};
+
+describe("prerun hook", () => {
+    const readFileSyncSpy = jest.spyOn(fs, "readFileSync");
+    const writeFileSyncSpy = jest.spyOn(fs, "writeFileSync");
+    const existsSyncSpy = jest.spyOn(fs, "existsSync");
+
+    const dataDir = "/users/user/Local/config/chs-dev";
+    const testConfig = {
+        dataDir,
+        root: "/users/user/.chs-dev"
+    };
+    const testContext = {
+        error: jest.fn()
+    };
+
+    const environmentConfigWithAuthedRepositories = {
+        env: {},
+        authenticatedRepositories: [
+            "123456789.dkr.ecr.eu-west-2.amazonaws.com"
+        ],
+        projectPath: "/users/user/docker-chs",
+        projectName: "docker-chs",
+        performEcrLoginHoursThreshold: 8
+    };
+    const environmentConfigWithoutAuthedRepositories = {
+        env: {},
+        authenticatedRepositories: [],
+        projectPath: "/users/user/docker-chs",
+        projectName: "docker-chs"
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        Date.now = () => Date.parse(testTimeIsoUtc);
+
+        delete process.env.CHS_DEV_FORCE_ECR_CHECK;
+    });
+
+    it("always run check when CHS_DEV_FORCE_ECR_CHECK is set", async () => {
+        process.env.CHS_DEV_FORCE_ECR_CHECK = "FORCE";
+
+        // @ts-expect-error
+        confirm.mockResolvedValue(true);
+
+        existsSyncSpy.mockReturnValue(true);
+
+        readFileSyncSpy.mockReturnValue(
+            Buffer.from(testTimeMinusHours(7), "utf8")
+        );
+
+        configLoaderMock.mockReturnValue(
+            environmentConfigWithAuthedRepositories
+        );
+
+        // @ts-expect-error
+        await hook({ config: testConfig, context: testContext });
+
+        expect(attemptLoginToDockerEcrMock).toHaveBeenCalled();
+    });
+
+    describe("when not run before", () => {
+        beforeEach(() => {
+            jest.resetAllMocks();
+
+            configLoaderMock.mockReturnValue(
+                environmentConfigWithAuthedRepositories
+            );
+
+            existsSyncSpy.mockReturnValue(false);
+
+        });
+
+        it("prompts user to confirm whether they want to login when authed repos present", async () => {
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(confirm).toHaveBeenCalledWith({
+                message: "Do you want to attempt to login to AWS ECR?"
+            });
+        });
+
+        it("attempts login when user confirms", async () => {
+            // @ts-expect-error
+            confirm.mockResolvedValue(true);
+
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(attemptLoginToDockerEcrMock).toHaveBeenCalled();
+        });
+
+        it("does not attempt to login if user does not confirm", async () => {
+            // @ts-expect-error
+            confirm.mockResolvedValue(false);
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(attemptLoginToDockerEcrMock).not.toHaveBeenCalled();
+        });
+
+        it("writes last runtime to file", async () => {
+            // @ts-expect-error
+            confirm.mockResolvedValue(true);
+
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(writeFileSyncSpy).toHaveBeenCalledWith(
+                join(dataDir, "docker-chs.prerun.last_run_time"),
+                testTimeIsoUtc
+            );
+        });
+
+        it("prompts user whether they want to continue if it fails", async () => {
+            // @ts-expect-error
+            confirm.mockResolvedValue(true);
+
+            attemptLoginToDockerEcrMock.mockRejectedValue(
+                new Error("Cannot locate configured AWS profiles") as never
+            );
+
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(confirm).toHaveBeenCalledTimes(2);
+            expect(confirm).toHaveBeenCalledWith({
+                message: "Was not able to login to ECR do you want to continue?"
+            });
+        });
+
+        it("errors when user does not want to continue when there was an error logging in", async () => {
+            // @ts-expect-error
+            confirm.mockResolvedValueOnce(true)
+                .mockResolvedValue(false);
+
+            attemptLoginToDockerEcrMock.mockRejectedValue(
+                new Error("Cannot locate configured AWS profiles") as never
+            );
+
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(testContext.error).toHaveBeenCalledWith(
+                new Error("not logged into AWS ECR")
+            );
+        });
+
+        it("updates the runtime when user continues after error", async () => {
+            // @ts-expect-error
+            confirm.mockResolvedValue(true);
+
+            attemptLoginToDockerEcrMock.mockRejectedValue(
+               new Error("Cannot locate configured AWS profiles") as never
+            );
+
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(writeFileSyncSpy).toHaveBeenCalled();
+        });
+
+        it("does not update runtime when user does not want to continue", async () => {
+            // @ts-expect-error
+            confirm.mockResolvedValueOnce(true)
+                .mockResolvedValue(false);
+
+            attemptLoginToDockerEcrMock.mockRejectedValue(
+                new Error("Cannot locate configured AWS profiles") as never
+            );
+
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(writeFileSyncSpy).not.toHaveBeenCalled();
+            expect(testContext.error).toHaveBeenCalledWith(
+                new Error("not logged into AWS ECR")
+            );
+        });
+
+        it("checks for presence of the last runtime file", async () => {
+            // @ts-expect-error
+            confirm.mockResolvedValue(true);
+
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(existsSyncSpy).toHaveBeenCalledWith(
+                join(dataDir, "docker-chs.prerun.last_run_time")
+            );
+
+        });
+
+        it("does nothing if there are no authed repos", async () => {
+            configLoaderMock.mockReturnValue(
+                environmentConfigWithoutAuthedRepositories
+            );
+
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(confirm).not.toHaveBeenCalled();
+            expect(writeFileSyncSpy).not.toHaveBeenCalled();
+            expect(attemptLoginToDockerEcrMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("prerun hook subsequent runs and there are authed repos", () => {
+
+        beforeEach(() => {
+            jest.resetAllMocks();
+
+            configLoaderMock.mockReturnValue(
+                environmentConfigWithAuthedRepositories
+            );
+
+            existsSyncSpy.mockReturnValue(true);
+
+        });
+
+        it("does not do anything when time has not passed threshold", async () => {
+            readFileSyncSpy.mockReturnValue(
+                Buffer.from(testTimeMinusHours(7), "utf8")
+            );
+
+            // @ts-expect-error
+            await hook({ config: testConfig, context: testContext });
+
+            expect(confirm).not.toHaveBeenCalled();
+            expect(writeFileSyncSpy).not.toHaveBeenCalled();
+            expect(attemptLoginToDockerEcrMock).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/test/run/compose-log-viewer.spec.ts
+++ b/test/run/compose-log-viewer.spec.ts
@@ -23,7 +23,9 @@ describe("ComposeLogViewer", () => {
 
         composeLogViewer = new ComposeLogViewer({
             env: {},
-            projectPath: "."
+            projectPath: ".",
+            authenticatedRepositories: [],
+            projectName: "docker-chs"
         }, loggerMock);
 
         spawnStreamMock = new EventEmitter();

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -23,7 +23,9 @@ describe("DockerCompose", () => {
             SSH_PRIVATE_KEY: sshPrivateKey,
             ANOTHER_VALUE: "another-value"
         },
-        projectPath: "./"
+        projectPath: "./",
+        authenticatedRepositories: [],
+        projectName: "project"
     };
 
     jest.mock("../../src/run/logs/PatternMatchingConsoleLogHandler", () => {
@@ -235,7 +237,9 @@ describe("DockerCompose", () => {
 
             const configMinusEnv = {
                 projectPath: "./",
-                env: {}
+                projectName: "project",
+                env: {},
+                authenticatedRepositories: []
             };
 
             const dockerComposeMinusEnv = new DockerCompose(configMinusEnv, logger);

--- a/test/run/docker-login.spec.ts
+++ b/test/run/docker-login.spec.ts
@@ -1,0 +1,93 @@
+import { beforeAll, expect, jest } from "@jest/globals";
+import fs from "fs";
+import { join } from "path";
+import LogEverythingLogHandler from "../../src/run/logs/LogEverythingLogHandler";
+
+describe("DockerLogin", () => {
+
+    let DockerEcrLogin;
+    let dockerLogin;
+
+    const spawnMock = jest.fn();
+
+    jest.mock("../../src/helpers/spawn-promise", () => {
+        return {
+            spawn: spawnMock
+        };
+    });
+
+    const authenticatedRepositories = [
+        "123456789.dkr.ecr.eu-west-1.amazonaws.com",
+        "123456789.dkr.ecr.eu-west-2.amazonaws.com",
+        "223456789.dkr.ecr.eu-west-2.amazonaws.com"
+    ];
+
+    const chsDevInstallDir = "/users/user/.chs-dev";
+
+    const loggerMock = {
+        log: jest.fn()
+    };
+
+    beforeAll(async () => {
+        ({ DockerEcrLogin } = await import("../../src/run/docker-ecr-login"));
+    });
+
+    describe("attemptToLoginToDockerEcr", () => {
+        const existsSyncSpy = jest.spyOn(fs, "existsSync");
+
+        beforeEach(() => {
+            jest.resetAllMocks();
+
+            dockerLogin = new DockerEcrLogin(chsDevInstallDir, {
+                env: {},
+                projectPath: ".",
+                authenticatedRepositories
+            }, loggerMock);
+
+        });
+
+        it("checks for aws configuration", async () => {
+            spawnMock.mockResolvedValue(undefined as never);
+
+            existsSyncSpy.mockReturnValue(true);
+
+            await dockerLogin.attemptLoginToDockerEcr();
+
+            expect(existsSyncSpy).toHaveBeenCalledWith(
+                join(process.env.HOME as string, ".aws/config")
+            );
+        });
+
+        it("rejects with error if no aws configuration", async () => {
+            spawnMock.mockResolvedValue(undefined as never);
+
+            existsSyncSpy.mockReturnValue(false);
+
+            await expect(dockerLogin.attemptLoginToDockerEcr()).rejects.toEqual(
+                new Error("Does not look like AWS has been configured")
+            );
+        });
+
+        it("runs login script for requested repos", async () => {
+            spawnMock.mockResolvedValue(undefined as never);
+
+            existsSyncSpy.mockReturnValue(true);
+
+            await dockerLogin.attemptLoginToDockerEcr();
+
+            expect(spawnMock).toHaveBeenCalledWith(
+                join(chsDevInstallDir, "bin/docker_login.sh"),
+                [
+                    "--",
+                    ...authenticatedRepositories
+                ], {
+                    logHandler: expect.any(LogEverythingLogHandler),
+                    spawnOptions: {
+                        shell: "/bin/bash"
+                    }
+                }
+            );
+        });
+    });
+
+});


### PR DESCRIPTION
* Create hook which logs into ECR if user wants to
* Hook calls script bin/docker_login.sh which uses the easy_aws_login.sh script installed using dev-env-setup or will
  attempt login using simpler mechanisms when not installed
