### PR TITLE
Handle env_file set for docker compose

### DIFF
--- a/src/run/service-loader.ts
+++ b/src/run/service-loader.ts
@@ -38,6 +38,8 @@ export class ServiceLoader {
         // Collect all services specifed by the state to include
         const loadedServices = this.inventory.services
             .filter(service => state.services.includes(service.name) || state.modules.includes(service.module))
+            // TODO: Remove after dual running period - RAND-397
+            .filter(service => !this.serviceIsDeprecated(service))
             .map(withLiveUpdate);
 
         // Collect all dependent services ensuring there are no duplicates
@@ -55,7 +57,12 @@ export class ServiceLoader {
     }
 
     private findService (serviceName: string): Service | undefined {
-        return this.inventory.services.find(service => service.name === serviceName);
+        return this.inventory.services.find(service => service.name === serviceName && !this.serviceIsDeprecated(service));
+    }
+
+    // TODO: Remove after dual running period - RAND-397
+    private serviceIsDeprecated (service: Service): boolean {
+        return service.source.includes("tilt");
     }
 
 }

--- a/test/generator/docker-compose-file-generator.spec.ts
+++ b/test/generator/docker-compose-file-generator.spec.ts
@@ -9,12 +9,15 @@ import { parse, stringify } from "yaml";
 
 describe("DockerComposeFileGenerator", () => {
     let tempDir: string;
+    let moduleDir: string;
     let dockerComposeFileGenerator: DockerComposeFileGenerator;
 
     beforeAll(() => {
         tempDir = mkdtempSync("docker-compose-file-gen");
+        moduleDir = join(tempDir, "services/modules/module-one");
 
         mkdirSync(join(tempDir, "local"));
+        mkdirSync(moduleDir, { recursive: true });
     });
 
     afterAll(() => {
@@ -180,7 +183,7 @@ describe("DockerComposeFileGenerator", () => {
         let serviceDockerComposeFile: string;
 
         beforeEach(() => {
-            serviceDockerComposeFile = join(tempDir, "service.docker-compose.yaml");
+            serviceDockerComposeFile = join(moduleDir, "service.docker-compose.yaml");
 
             copyFileSync(
                 join(process.cwd(), "test/data/docker-compose-file-generator/service.docker-compose.yaml"),
@@ -498,7 +501,7 @@ describe("DockerComposeFileGenerator", () => {
                 "chs.local.builder.languageVersion=17"
             ];
 
-            initialServiceDefinition.services["service-one"].env_file = "services/modules/module-one/service-one.env";
+            initialServiceDefinition.services["service-one"].env_file = "service-one.env";
 
             writeFileSync(
                 serviceDockerComposeFile,
@@ -543,9 +546,9 @@ describe("DockerComposeFileGenerator", () => {
             ];
 
             initialServiceDefinition.services["service-one"].env_file = [
-                "services/modules/module-one/service-one.env",
-                "services/modules/module-one/service-one.env2",
-                "services/modules/module-one/service-one.env3"
+                "service-one.env",
+                "service-one.env2",
+                "../module-two/service-one.env3"
             ];
 
             writeFileSync(
@@ -579,7 +582,7 @@ describe("DockerComposeFileGenerator", () => {
             expect(generatedDockerCompose.services["service-one"].env_file).toEqual([
                 "../../services/modules/module-one/service-one.env",
                 "../../services/modules/module-one/service-one.env2",
-                "../../services/modules/module-one/service-one.env3"
+                "../../services/modules/module-two/service-one.env3"
             ]);
         });
     });

--- a/test/run/service-loader.spec.ts
+++ b/test/run/service-loader.spec.ts
@@ -5,13 +5,22 @@ import State from "../../src/model/State";
 import { deduplicate } from "../../src/helpers/array-reducers";
 import { Inventory } from "../../src/state/inventory";
 import { ServiceLoader } from "../../src/run/service-loader";
-import { tree } from "@oclif/core/lib/cli-ux";
 
 const serviceOne = {
     name: "service-one",
     module: "module-one",
     source: "./module-one/service-one.docker-compose.yaml",
     dependsOn: [],
+    repository: null,
+    builder: "",
+    metadata: {}
+};
+
+const serviceTwoTilt = {
+    name: "service-two",
+    module: "module-one",
+    source: "./module-one/tilt/service-two.docker-compose.yaml",
+    dependsOn: ["service-one"],
     repository: null,
     builder: "",
     metadata: {}
@@ -137,8 +146,19 @@ const serviceTen = {
     metadata: {}
 };
 
+const serviceTenTilt = {
+    name: "service-ten",
+    module: "module-four",
+    source: "./module-four/tilt/service-ten.docker-compose.yaml",
+    dependsOn: [],
+    repository: null,
+    builder: "",
+    metadata: {}
+};
+
 const services: Service[] = [
     serviceOne,
+    serviceTwoTilt,
     serviceTwo,
     serviceThree,
     serviceFour,
@@ -147,7 +167,8 @@ const services: Service[] = [
     serviceSeven,
     serviceEight,
     serviceNine,
-    serviceTen
+    serviceTen,
+    serviceTenTilt
 ];
 
 const modules: Module[] = services.map(service => service.module)


### PR DESCRIPTION
* env_file will have a value relative to the docker compose spec file therefore to set the new relative path from the development docker compose spec
* Given env_file needs to be different for tilt (deprecated) need to filter them out prior to generating docker compose spec
