### PR TITLE
Allow services to always build from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ $ npm install -g chs-dev
 $ chs-dev COMMAND
 running command...
 $ chs-dev (--version)
-chs-dev/0.1.0 darwin-arm64 node-v20.10.0
+chs-dev/1.1.0 darwin-arm64 node-v20.10.0
 $ chs-dev --help [COMMAND]
 USAGE
   $ chs-dev COMMAND
@@ -650,6 +650,10 @@ are referenced by chs-dev for the given purposes:
 * `chs.local.entrypoint` - specifies the entrypoint script for a given service
   typically for a node application which does not have a
   `ecs-image-buid/docker_start.sh` file
+* `chs.local.repositoryRequired` - marks the service as requiring the
+  repository locally in order to be run. This is useful where there may not be
+  a remote repository to use for the service. The service can define its own
+  build configuration referencing its repository/Dockerfile.
 
 #### Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chs-dev",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chs-dev",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/confirm": "^3.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chs-dev",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Damian Dunajski (ddunajski@companieshouse.gov.uk)",
   "bin": {
     "chs-dev": "./bin/run.js"

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -1,0 +1,37 @@
+import simpleGit from "simple-git";
+
+type CloneRepoOpts = {
+    repositoryUrl: string;
+    destinationPath: string;
+    branch?: string | null;
+}
+
+/**
+ * Clones the supplied repository to the destinationPath optionally checking
+ * out a named branch
+ * @param cloneRepoOptions - Options regarding the clone operation containing
+ *          the repository and destination information
+ * @returns Promise
+ */
+export const cloneRepo = ({ repositoryUrl, destinationPath, branch }: CloneRepoOpts) => {
+    // @ts-ignore
+    const git = simpleGit();
+
+    const gitArgs = branch ? ["--branch", branch] : [];
+
+    return git.clone(
+        repositoryUrl, destinationPath, gitArgs
+    );
+};
+
+/**
+ * Updates the code of the repository at the path specified by doing a Git pull
+ * @param destinationPath path to repository being updated
+ * @returns Promise
+ */
+export const updateRepo = (destinationPath: string) => {
+    // @ts-ignore
+    const git = simpleGit(destinationPath);
+
+    return git.pull();
+};

--- a/src/state/permanent-repositories.ts
+++ b/src/state/permanent-repositories.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from "fs";
+import Config from "../model/Config.js";
+import { Inventory } from "./inventory.js";
+import { join } from "path";
+import yaml from "yaml";
+import { cloneRepo, updateRepo } from "../helpers/git.js";
+import Service from "../model/Service.js";
+
+/**
+ * Manages the state of the repositories which are permanent - i.e. required
+ * to run the service.
+ */
+export class PermanentRepositories {
+
+    // eslint-disable-next-line no-useless-constructor
+    constructor (private readonly config: Config, private readonly inventory: Inventory) {}
+
+    /**
+     * Ensures that repositories exist and are up to date for each of the
+     * services which require a copy of a local repository
+     * @returns Promise based on the outcome of the action
+     */
+    async ensureAllExistAndAreUpToDate (): Promise<void> {
+
+        const dockerComposeSpec = yaml.parse(readFileSync(join(this.config.projectPath, "docker-compose.yaml")).toString("utf8"));
+
+        for (const includedSpecFile of dockerComposeSpec.include) {
+            const service = this.findServiceWithSource(includedSpecFile);
+
+            if (service) {
+                console.log(`Updating ${service.name}`);
+
+                const localRepoPath = join(this.config.projectPath, "repositories", service.name);
+
+                if (!existsSync(localRepoPath)) {
+                    await this.cloneServiceRepo(service, localRepoPath);
+
+                    continue;
+                }
+
+                await updateRepo(localRepoPath);
+            }
+        }
+    }
+
+    private findServiceWithSource (includedSpecFile: any) {
+        return this.inventory.services.find(({ source, metadata }) => source === includedSpecFile && metadata.repositoryRequired === "true");
+    }
+
+    private cloneServiceRepo (service: Service, localRepoPath: string) {
+        if (service.repository) {
+            return cloneRepo({
+                repositoryUrl: service.repository.url,
+                destinationPath: localRepoPath,
+                branch: service.repository.branch
+            });
+        } else {
+            throw new Error(`Service: ${service.name} has not been configured with a repository`);
+        }
+    }
+}

--- a/src/state/service-reader.ts
+++ b/src/state/service-reader.ts
@@ -39,7 +39,8 @@ const metadataLabelMapping = {
     languageMajorVersion: "chs.local.builder.languageVersion",
     dockerfile: "chs.local.dockerfile",
     entrypoint: "chs.local.entrypoint",
-    buildOutputDir: "chs.local.builder.outputDir"
+    buildOutputDir: "chs.local.builder.outputDir",
+    repositoryRequired: "chs.local.repositoryRequired"
 };
 
 const readService: (module: string, source: string, serviceName: string, service: ServiceDefinition) => Partial<Service> = (module, source, serviceName, service) => ({

--- a/test/commands/up.spec.ts
+++ b/test/commands/up.spec.ts
@@ -8,6 +8,7 @@ const startDevelopmentModeMock = jest.fn();
 const dockerComposeUpMock = jest.fn();
 const dependencyCacheUpdateMock = jest.fn();
 const composeLogViewerViewMock = jest.fn();
+const permanentRepositoriesEnsureAllExistAndAreUpToDateMock = jest.fn();
 
 const NO_SERVICES_IN_DEV_MODE = {
     modules: [],
@@ -112,6 +113,16 @@ jest.mock("../../src/run/compose-log-viewer", () => {
     };
 });
 
+jest.mock("../../src/state/permanent-repositories", () => {
+    return {
+        PermanentRepositories: function () {
+            return {
+                ensureAllExistAndAreUpToDate: permanentRepositoriesEnsureAllExistAndAreUpToDateMock
+            };
+        }
+    };
+});
+
 describe("Up command", () => {
     let up: Up;
     let testConfig: Config;
@@ -136,6 +147,12 @@ describe("Up command", () => {
         jest.resetAllMocks();
 
         setUpCommand(NO_SERVICES_IN_DEV_MODE);
+    });
+
+    it("should ensure all permanent repos are present", async () => {
+        await up.run();
+
+        expect(permanentRepositoriesEnsureAllExistAndAreUpToDateMock).toHaveBeenCalled();
     });
 
     it("should call up", async () => {

--- a/test/data/service-reader/modules/module-one/repository-required.docker-compose.yaml
+++ b/test/data/service-reader/modules/module-one/repository-required.docker-compose.yaml
@@ -1,0 +1,19 @@
+---
+# Any changes to this file also need to be made to the tilt/ version
+# for backwards compatibility
+version: "3.8"
+services:
+  repo-required:
+    labels:
+      - traefik.http.routers.ewf.rule=Host(`svc1.chl.local`)
+      - chs.repository.url=git@github.com:companieshouse/repo1.git
+      - chs.local.repositoryRequired=true
+      - chs.local.dockerfile=svc1.Dockerfile
+    image: ewf:latest
+    build:
+      context: ../../../repositories/repo-required
+      dockerfile: svc1.Dockerfile
+    expose:
+      - 8000
+    ports:
+      - "8000:8000"

--- a/test/helpers/git.spec.ts
+++ b/test/helpers/git.spec.ts
@@ -1,0 +1,67 @@
+import { expect, jest } from "@jest/globals";
+import { cloneRepo, updateRepo } from "../../src/helpers/git";
+import simpleGitMock from "simple-git";
+
+const gitCloneMock = jest.fn();
+const gitPullMock = jest.fn();
+
+jest.mock("simple-git");
+
+describe("cloneRepo", () => {
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        // @ts-expect-error
+        simpleGitMock.mockReturnValue({
+            clone: gitCloneMock,
+            pull: gitPullMock
+        });
+    });
+
+    it("clones with branch to location", async () => {
+        await cloneRepo({
+            repositoryUrl: "git@github.com:companieshouse/repo1.git",
+            destinationPath: "./local/svc1"
+        });
+
+        expect(gitCloneMock).toHaveBeenCalledWith(
+            "git@github.com:companieshouse/repo1.git",
+            "./local/svc1",
+            []
+        );
+    });
+
+    it("clones with branch to location with branch", async () => {
+        await cloneRepo({
+            repositoryUrl: "git@github.com:companieshouse/repo1.git",
+            destinationPath: "./local/svc1",
+            branch: "not-main"
+        });
+
+        expect(gitCloneMock).toHaveBeenCalledWith(
+            "git@github.com:companieshouse/repo1.git",
+            "./local/svc1",
+            ["--branch", "not-main"]
+        );
+    });
+});
+
+describe("updateRepo", () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        // @ts-expect-error
+        simpleGitMock.mockReturnValue({
+            clone: gitCloneMock,
+            pull: gitPullMock
+        });
+    });
+
+    it("pulls repo", async () => {
+        await updateRepo("./local/svc1");
+
+        expect(simpleGitMock).toHaveBeenCalledWith("./local/svc1");
+        expect(gitPullMock).toHaveBeenCalled();
+    });
+});

--- a/test/state/__snapshots__/service-reader.spec.ts.snap
+++ b/test/state/__snapshots__/service-reader.spec.ts.snap
@@ -123,3 +123,26 @@ exports[`readServices loads atypical with repoContext 1`] = `
   },
 ]
 `;
+
+exports[`readServices loads service with repo required 1`] = `
+[
+  {
+    "builder": "",
+    "dependsOn": [],
+    "description": undefined,
+    "metadata": {
+      "dockerfile": "svc1.Dockerfile",
+      "healthcheck": undefined,
+      "ingressRoute": "Host(\`svc1.chl.local\`)",
+      "repositoryRequired": "true",
+    },
+    "module": "module-one",
+    "name": "repo-required",
+    "repository": {
+      "branch": undefined,
+      "url": "git@github.com:companieshouse/repo1.git",
+    },
+    "source": "./test/data/service-reader/modules/module-one/repository-required.docker-compose.yaml",
+  },
+]
+`;

--- a/test/state/permanent-repositories.spec.ts
+++ b/test/state/permanent-repositories.spec.ts
@@ -1,0 +1,222 @@
+import { expect, jest } from "@jest/globals";
+import { cloneRepo as cloneRepoMock, updateRepo as updateRepoMock } from "../../src/helpers/git";
+import fs from "fs";
+import Service from "../../src/model/Service";
+import yaml from "yaml";
+import { PermanentRepositories } from "../../src/state/permanent-repositories";
+import Config from "../../src/model/Config";
+import { Inventory } from "../../src/state/inventory";
+import { join } from "path";
+
+jest.mock("../../src/helpers/git");
+
+const serviceOne = {
+    name: "service-one",
+    module: "module-one",
+    source: "services/modules/module-one/service-one.docker-compose.yaml",
+    dependsOn: [],
+    repository: {
+        url: "git@github.com:companieshouse/repo1.git"
+    },
+    builder: "",
+    metadata: {
+        repositoryRequired: "true"
+    }
+};
+const serviceTwo = {
+    name: "service-two",
+    module: "module-one",
+    source: "services/modules/module-one/service-two.docker-compose.yaml",
+    dependsOn: [],
+    repository: {
+        url: "git@github.com:companieshouse/repo2.git"
+    },
+    builder: "",
+    metadata: {}
+};
+const serviceThree = {
+    name: "service-three",
+    module: "module-one",
+    source: "services/modules/module-one/service-three.docker-compose.yaml",
+    dependsOn: [],
+    repository: {
+        url: "git@github.com:companieshouse/repo3.git",
+        branch: "develop"
+    },
+    builder: "",
+    metadata: {
+        repositoryRequired: "true"
+    }
+};
+const serviceFour = {
+    name: "service-four",
+    module: "module-two",
+    source: "services/modules/module-two/service-four.docker-compose.yaml",
+    dependsOn: [],
+    repository: {
+        url: "git@github.com:companieshouse/repo4.git"
+    },
+    builder: "",
+    metadata: {}
+};
+const serviceFive = {
+    name: "service-five",
+    module: "module-two",
+    source: "services/modules/module-one/service-five.docker-compose.yaml",
+    dependsOn: [],
+    repository: null,
+    builder: "",
+    metadata: {
+        repositoryRequired: "true"
+    }
+};
+
+const services: Service[] = [
+    serviceOne,
+    serviceTwo,
+    serviceThree,
+    serviceFour,
+    serviceFive
+];
+
+const inventoryMock = {
+    services
+};
+
+const config: Config = {
+    projectName: "chs-docker",
+    projectPath: "./chs-docler",
+    env: {},
+    authenticatedRepositories: []
+};
+
+const dockerComposeConfigurationIncludingServices = (...services: Service[]) => {
+    const dockerComposeConfiguration = {
+        services: {},
+        include: services.map(service => service.source)
+    };
+
+    return yaml.stringify(dockerComposeConfiguration);
+};
+
+describe("PermanentRepositories", () => {
+    const readFileSyncMock = jest.spyOn(fs, "readFileSync");
+    const existsSyncMock = jest.spyOn(fs, "existsSync");
+
+    let permanentRepositories: PermanentRepositories;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        permanentRepositories = new PermanentRepositories(config, inventoryMock as Inventory);
+
+        readFileSyncMock.mockReturnValue(
+            Buffer.from(dockerComposeConfigurationIncludingServices(serviceOne), "utf8")
+        );
+
+        existsSyncMock.mockReturnValue(false);
+    });
+
+    it("reads in the docker compose spec", async () => {
+        await permanentRepositories.ensureAllExistAndAreUpToDate();
+
+        expect(readFileSyncMock).toHaveBeenCalledWith(join(config.projectPath, "docker-compose.yaml"));
+    });
+
+    it("it checks whether permanent repository exists", async () => {
+        await permanentRepositories.ensureAllExistAndAreUpToDate();
+
+        expect(existsSyncMock).toHaveBeenCalledWith(join(config.projectPath, "repositories", serviceOne.name));
+    });
+
+    it("clones repo when permanent repo has not be cloned", async () => {
+        await permanentRepositories.ensureAllExistAndAreUpToDate();
+
+        expect(cloneRepoMock).toHaveBeenCalledWith({
+            repositoryUrl: serviceOne.repository.url,
+            destinationPath: join(config.projectPath, "repositories", serviceOne.name)
+        });
+    });
+
+    it("clones repo with branch when permanent repo specifies branch", async () => {
+        readFileSyncMock.mockReturnValue(
+            Buffer.from(dockerComposeConfigurationIncludingServices(serviceThree), "utf8")
+        );
+
+        await permanentRepositories.ensureAllExistAndAreUpToDate();
+
+        expect(cloneRepoMock).toHaveBeenCalledWith({
+            repositoryUrl: serviceThree.repository.url,
+            destinationPath: join(config.projectPath, "repositories", serviceThree.name),
+            branch: serviceThree.repository.branch
+        });
+    });
+
+    it("Does not update repo when does not need to as it is newly cloned", async () => {
+        await permanentRepositories.ensureAllExistAndAreUpToDate();
+
+        expect(updateRepoMock).not.toHaveBeenCalled();
+    });
+
+    it("does not clone repo when local repo already exists", async () => {
+        existsSyncMock.mockReturnValue(true);
+
+        await permanentRepositories.ensureAllExistAndAreUpToDate();
+
+        expect(cloneRepoMock).not.toHaveBeenCalled();
+    });
+
+    it("updates repo when local repo already exists", async () => {
+        existsSyncMock.mockReturnValue(true);
+
+        await permanentRepositories.ensureAllExistAndAreUpToDate();
+
+        expect(updateRepoMock).toHaveBeenCalledWith(
+            join(config.projectPath, "repositories", serviceOne.name)
+        );
+    });
+
+    it("does not do anything when service is not a permananent repo", async () => {
+        readFileSyncMock.mockReturnValue(
+            Buffer.from(dockerComposeConfigurationIncludingServices(serviceTwo), "utf8")
+        );
+
+        await permanentRepositories.ensureAllExistAndAreUpToDate();
+
+        expect(cloneRepoMock).not.toHaveBeenCalled();
+
+        expect(updateRepoMock).not.toHaveBeenCalled();
+
+        expect(existsSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("can handle multiple services", async () => {
+        existsSyncMock.mockReturnValueOnce(false)
+            .mockReturnValue(true);
+
+        readFileSyncMock.mockReturnValue(
+            Buffer.from(dockerComposeConfigurationIncludingServices(
+                serviceOne,
+                serviceTwo,
+                serviceThree,
+                serviceFour
+            ), "utf8")
+        );
+
+        await permanentRepositories.ensureAllExistAndAreUpToDate();
+
+        expect(cloneRepoMock).toHaveBeenCalledTimes(1);
+        expect(updateRepoMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects if service does not have repository when repo required", async () => {
+
+        readFileSyncMock.mockReturnValue(
+            Buffer.from(dockerComposeConfigurationIncludingServices(serviceFive), "utf8")
+        );
+
+        await expect(permanentRepositories.ensureAllExistAndAreUpToDate()).rejects.toEqual(
+            new Error("Service: " + serviceFive.name + " has not been configured with a repository")
+        );
+    });
+});

--- a/test/state/service-reader.spec.ts
+++ b/test/state/service-reader.spec.ts
@@ -28,6 +28,11 @@ const anotherAtypicalServiceFile = join(
     "test/data/service-reader/modules/module-three/another-atypical.docker-compose.yaml"
 );
 
+const repositoryRequiredServiceFile = join(
+    process.cwd(),
+    "test/data/service-reader/modules/module-one/repository-required.docker-compose.yaml"
+);
+
 const normaliseLocations = (svcs: Partial<Service>[]) => {
     return svcs.map(svc => {
         svc.source = svc.source?.replace(process.cwd(), ".");
@@ -55,5 +60,9 @@ describe("readServices", () => {
 
     it("loads atypical with entrypoint and outdir", () => {
         expect(normaliseLocations(readServices(anotherAtypicalServiceFile))).toMatchSnapshot();
+    });
+
+    it("loads service with repo required", () => {
+        expect(normaliseLocations(readServices(repositoryRequiredServiceFile))).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
* Given some older perl repos do not have ECR build behind them they need to be built locally
* Introduce a  new utility for interacting with Git
