### PR TITLE
Add check to init hook to confirm version matches project

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,8 @@ within the current working directory.
 * `GITHUB_PAT` - when supplied will use the PAT value to authenticate with
   Github to reduce the likelihood of encountering rate limits when interacting
   with GitHub's API.
+* `CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING` - when set does not show any
+  warnings relating to version not being suitable for project.
 
 ### Service configuration
 

--- a/test/hooks/__snapshots__/init.spec.ts.snap
+++ b/test/hooks/__snapshots__/init.spec.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`init hook first run through displays correct message when the installed version not meeting project 1`] = `
+[
+  [
+    "WARNING: this version: 0.9.23 does not meet the project requirements: >=1.0.0 <2.0.0
+
+Run:
+
+	chs-dev sync
+
+to update chs-dev to a suitable version
+--------------------------------------------------------------------------------
+
+",
+  ],
+]
+`;
+
 exports[`init hook first run through displays correct message when there is newer version: 1.1.2 1`] = `
 [
   [
@@ -110,6 +127,23 @@ to update to latest version
 
 
 ================================================================================",
+  ],
+]
+`;
+
+exports[`init hook subsequent run through displays correct message when the installed version not meeting project 1`] = `
+[
+  [
+    "WARNING: this version: 0.9.23 does not meet the project requirements: >=1.0.0 <2.0.0
+
+Run:
+
+	chs-dev sync
+
+to update chs-dev to a suitable version
+--------------------------------------------------------------------------------
+
+",
   ],
 ]
 `;

--- a/test/hooks/init.spec.ts
+++ b/test/hooks/init.spec.ts
@@ -3,14 +3,12 @@ import { Hook, IConfig } from "@oclif/config";
 // @ts-expect-error
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
+import { getLatestReleaseVersion as getLatestReleaseVersionMock } from "../../src/helpers/latest-release";
+import { load as configLoadMock } from "../../src/helpers/config-loader";
+import Config from "../../src/model/Config";
 
-const getLatestReleaseVersionMock = jest.fn();
-
-jest.mock("../../src/helpers/latest-release", () => {
-    return {
-        getLatestReleaseVersion: getLatestReleaseVersionMock
-    };
-});
+jest.mock("../../src/helpers/latest-release");
+jest.mock("../../src/helpers/config-loader");
 
 describe("init hook", () => {
 
@@ -28,6 +26,13 @@ describe("init hook", () => {
         ["2.0.1", `📣 There is a newer major version (2.0.1) available (current version: ${version})`],
         ["2.1.0", `📣 There is a newer major version (2.1.0) available (current version: ${version})`]
     ];
+    const projectConfig: Config = {
+        env: {},
+        projectPath: "./docker-project",
+        projectName: "docker-project",
+        authenticatedRepositories: [],
+        versionSpecification: ">=1.0.0 <2.0.0"
+    };
 
     const pjson = {
         "chs-dev": {
@@ -63,6 +68,11 @@ describe("init hook", () => {
 
             // @ts-expect-error
             getLatestReleaseVersionMock.mockResolvedValue(version);
+
+            // @ts-expect-error
+            configLoadMock.mockReturnValue(projectConfig);
+
+            delete process.env.CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING;
         });
 
         it("should make data dir when not already in existence", async () => {
@@ -123,6 +133,26 @@ describe("init hook", () => {
                 expect(consoleLogSpy.mock.calls).toMatchSnapshot();
             });
         }
+
+        it("displays correct message when the installed version not meeting project", async () => {
+            // @ts-expect-error
+            getLatestReleaseVersionMock.mockResolvedValue("0.9.23");
+
+            const consoleLogSpy = jest.spyOn(console, "log");
+
+            // @ts-expect-error
+            await initHook({
+                config: {
+                    ...testConfig,
+                    version: "0.9.23"
+                },
+                id: "",
+                argv: [],
+                context: jest.fn()
+            });
+
+            expect(consoleLogSpy.mock.calls).toMatchSnapshot();
+        });
     });
 
     describe("subsequent run through", () => {
@@ -151,6 +181,11 @@ describe("init hook", () => {
 
             // @ts-expect-error
             Date.now = dateNowMock;
+
+            // @ts-expect-error
+            configLoadMock.mockReturnValue(projectConfig);
+
+            delete process.env.CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING;
         });
 
         it("checks version when after time passed", async () => {
@@ -221,6 +256,48 @@ describe("init hook", () => {
             });
 
             expect(getLatestReleaseVersionMock).toHaveBeenCalled();
+        });
+
+        it("displays correct message when the installed version not meeting project", async () => {
+            // @ts-expect-error
+            getLatestReleaseVersionMock.mockResolvedValue("0.9.23");
+
+            const consoleLogSpy = jest.spyOn(console, "log");
+
+            // @ts-expect-error
+            await initHook({
+                config: {
+                    ...testConfig,
+                    version: "0.9.23"
+                },
+                id: "",
+                argv: [],
+                context: jest.fn()
+            });
+
+            expect(consoleLogSpy.mock.calls).toMatchSnapshot();
+        });
+
+        it("does not display message when the installed version not meeting project and env var set", async () => {
+            // @ts-expect-error
+            getLatestReleaseVersionMock.mockResolvedValue("0.9.23");
+
+            const consoleLogSpy = jest.spyOn(console, "log");
+
+            process.env.CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING = "true";
+
+            // @ts-expect-error
+            await initHook({
+                config: {
+                    ...testConfig,
+                    version: "0.9.23"
+                },
+                id: "",
+                argv: [],
+                context: jest.fn()
+            });
+
+            expect(consoleLogSpy).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
* init hook will check the installed version matches the project configuration
  and suggest the user runs `chs-dev sync` which will synchronise the versions
  much like fly when it does not match the concourse version
