### PR TITLE
Change logging in  status so that (undefined) does not show when service is not running

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -45,7 +45,7 @@ export default class Status extends Command {
         const state = this.stateManager.snapshot;
         const dockerComposeState = this.dockerCompose.getServiceStatuses();
 
-        const serviceState = (serviceName: string) => dockerComposeState ? `(${dockerComposeState[serviceName]})` || "(Not running)" : "";
+        const serviceState = (serviceName: string) => dockerComposeState ? `(${dockerComposeState[serviceName] || "Not running"})` : "";
         const { flags } = await this.parse(Status);
 
         const enabledServiceNames = this.inventory.services

--- a/test/commands/__snapshots__/status.spec.ts.snap
+++ b/test/commands/__snapshots__/status.spec.ts.snap
@@ -80,6 +80,50 @@ Manually deactivated services:",
 ]
 `;
 
+exports[`Status command should log with their docker compose statuses correctly when not running 1`] = `
+[
+  [
+    "Manually activated modules:",
+  ],
+  [
+    " - module-one",
+  ],
+  [
+    "
+Manually activated services:",
+  ],
+  [
+    " - service-one (running)",
+  ],
+  [
+    " - service-two (running)",
+  ],
+  [
+    "
+Automatically activated services:",
+  ],
+  [
+    " - service-five (stopped) ",
+  ],
+  [
+    " - service-four (Not running) ",
+  ],
+  [
+    " - service-one (running) ",
+  ],
+  [
+    " - service-two (running) [LIVE UPDATE]",
+  ],
+  [
+    "
+Manually deactivated services:",
+  ],
+  [
+    " - service-three",
+  ],
+]
+`;
+
 exports[`Status command should log without docker compose statuses 1`] = `
 [
   [

--- a/test/commands/status.spec.ts
+++ b/test/commands/status.spec.ts
@@ -164,6 +164,20 @@ describe("Status command", () => {
         expect(logMock.mock.calls).toMatchSnapshot();
     });
 
+    it("should log with their docker compose statuses correctly when not running", async () => {
+        getServiceStatusesMock.mockReturnValue({
+            "service-one": "running",
+            "service-two": "running",
+            "service-five": "stopped"
+        });
+
+        await status.run();
+
+        expect(logMock).toHaveBeenCalledTimes(12);
+
+        expect(logMock.mock.calls).toMatchSnapshot();
+    });
+
     it("should log json correctly", async () => {
         parseMock.mockResolvedValue({
             flags: {


### PR DESCRIPTION
* The || operator was placed in wrong position meaning that when services were enabled but not running (undefined) was logged
