### PR TITLE
Only enable dev mode when a service that is enabled is in live update

### DIFF
--- a/test/utils/data.ts
+++ b/test/utils/data.ts
@@ -132,6 +132,17 @@ export const services = [
             url: "git@github.com/companieshouse/repo-eleven.git"
         },
         metadata: {}
+    },
+    {
+        name: "service-twelve",
+        module: "module-five",
+        source: "docker-project/services/modules/module-five/service-twelve.docker-compose.yaml",
+        dependsOn: [],
+        builder: "",
+        repository: {
+            url: "git@github.com/companieshouse/repo-eleven.git"
+        },
+        metadata: {}
     }
 ];
 


### PR DESCRIPTION
* Correct check performed in up command that determines whether any of the services were in dev mode/live update. Rather than just checking that there are services in live update - confirms that the services are enabled.
