### PR TITLE
Add Check for being on VPN (or accessing internal resources) to init

### DIFF
--- a/src/helpers/vpn-check.ts
+++ b/src/helpers/vpn-check.ts
@@ -1,0 +1,29 @@
+import { execSync } from "child_process";
+
+const webproxyHost = "websenseproxy.internal.ch";
+const statisticsPattern = /received,\s([^%]+%).packet.loss/;
+
+/**
+ * Checks whether current machine can access the internal proxy server, if so
+ * it would indicate that they are able to access internal services.
+ * @returns boolean indicating whether the current machine can access the proxy
+ */
+export const isOnVpn = () => {
+    try {
+        const stdout = execSync(`ping -c 3 ${webproxyHost}`).toString("utf8");
+
+        const statisticsMatches = stdout.match(statisticsPattern);
+
+        if (statisticsMatches) {
+            const matchPercentage = statisticsMatches[1];
+
+            if (matchPercentage !== "100.0%") {
+                return true;
+            }
+        }
+
+    } catch (error) {
+        console.error(error);
+    }
+    return false;
+};

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -1,116 +1,27 @@
 import { Hook } from "@oclif/config";
 
-import { diff, satisfies } from "semver";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { getLatestReleaseVersion } from "../helpers/latest-release.js";
-import { join } from "path";
 import { load } from "../helpers/config-loader.js";
-import Config from "../model/Config.js";
+import { isOnVpn } from "../helpers/vpn-check.js";
+import { VersionCheck } from "../run/version-check.js";
 
 export const hook: Hook<"init"> = async function (options) {
 
     const projectConfig = load();
 
-    if (!isEnvVarSet("CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING") &&
-        !isSuitableVersionForProject(options.config.version, projectConfig)) {
-
-        logUnsuitableVersion(options.config.version, projectConfig.versionSpecification as string);
-
-        return;
+    if (!isOnVpn()) {
+        this.warn("Not on VPN. Some containers may not build properly.");
     }
 
-    const runTimeFile = join(options.config.dataDir, "last-version-run-time");
-    const executionTime = Date.now();
-    const runThresholdDays = options.config.pjson["chs-dev"]["version-check-schedule"]["number-of-days"];
+    const versionCheck = VersionCheck.create({
+        dataDirectory: options.config.dataDir,
+        runThresholdDays: parseInt(options.config.pjson["chs-dev"]["version-check-schedule"]["number-of-days "]),
+        config: projectConfig,
+        logger: {
+            warn: (msg) => this.warn(msg),
+            info: (msg) => this.log(msg)
+        }
+    });
 
-    const dataDirectoryExists = existsSync(options.config.dataDir);
+    await versionCheck.run(options.config.version);
 
-    const checkVersion: boolean = isEnvVarSet("CHS_DEV_CHECK_VERSION") || !(
-        dataDirectoryExists && existsSync(runTimeFile) && hasBeenRunRecently(executionTime, runThresholdDays, runTimeFile)
-    );
-
-    if (!dataDirectoryExists) {
-        mkdirSync(options.config.dataDir, { recursive: true });
-    }
-
-    if (checkVersion) {
-        await checkCurrentVersionOfCliIsLatest(options);
-
-        writeFileSync(
-            runTimeFile,
-            new Date(executionTime).toISOString()
-        );
-    }
-
-};
-
-const isSuitableVersionForProject = (version: string, projectConfig: Config) => {
-    return !projectConfig.versionSpecification || satisfies(version, projectConfig.versionSpecification);
-};
-
-const hasBeenRunRecently: (executionTime: number, dayThreshold: string, runTimeFile: string) => boolean = (executionTime: number, dayThreshold: string, runTimeFile: string) => {
-    let runRecently: boolean = true;
-
-    const lastRun = readFileSync(runTimeFile).toString("utf8");
-
-    const difference = executionTime - Date.parse(lastRun);
-
-    const numberOfDaysLapsed = Math.floor(
-        difference / (60 * 60 * 24 * 1000)
-    );
-
-    if (numberOfDaysLapsed >= parseInt(dayThreshold)) {
-        runRecently = false;
-    }
-
-    return runRecently;
-};
-
-const checkCurrentVersionOfCliIsLatest = async (options) => {
-    const latestVersion = await getLatestReleaseVersion();
-    const currentVersion = options.config.version;
-
-    const semverDifference = diff(latestVersion, currentVersion);
-
-    if (semverDifference !== null) {
-        logVersionDifference(latestVersion, currentVersion, semverDifference);
-    }
-};
-
-const logVersionDifference = (latestVersion: string, currentVersion: string, semverDifference: string) => {
-    const versionDifference: string = semverDifference === "major" || semverDifference === "minor"
-        ? ` ${semverDifference}`
-        : "";
-
-    const sepLine = "=".repeat(80);
-    const versionOutOfDateMessage = `📣 There is a newer${versionDifference} version (${latestVersion}) available (current version: ${currentVersion})
-
-Run:
-
-\tchs-dev sync
-
-to update to latest version
-`;
-
-    console.log(
-        `${sepLine}\n\n${versionOutOfDateMessage}\n\n${sepLine}`
-    );
-};
-
-const isEnvVarSet = (envVarName: string) => envVarName in process.env;
-
-const logUnsuitableVersion = (actualVersion: string, requiredVersionSpecification: string) => {
-    const sepLine = "-".repeat(80);
-    console.log(
-        `WARNING: this version: ${actualVersion} does not meet the project requirements: ${requiredVersionSpecification}
-
-Run:
-
-\tchs-dev sync
-
-to update chs-dev to a suitable version
-${sepLine}
-
-`
-    );
 };

--- a/src/run/version-check.ts
+++ b/src/run/version-check.ts
@@ -1,0 +1,139 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import Config from "../model/Config.js";
+import { diff, satisfies } from "semver";
+import { getLatestReleaseVersion } from "../helpers/latest-release.js";
+import { join } from "path";
+import { ThresholdUnit, timeWithinThreshold } from "../helpers/time-within-threshold.js";
+
+type VersionCheckLogger = {
+    warn: (msg: string) => void;
+    info: (msg: string) => void;
+}
+
+type CreateArguments = {
+    dataDirectory: string;
+    runThresholdDays: number;
+    logger: VersionCheckLogger;
+    config: Config;
+}
+
+/**
+ * A class which checks the version of the project and logs out any
+ * inconsistencies to latest version or project version
+ */
+export class VersionCheck {
+
+    // eslint-disable-next-line no-useless-constructor
+    private constructor (private readonly dataDirectory: string,
+        private readonly runThresholdDays: number,
+        private readonly logger: VersionCheckLogger,
+        private readonly config: Config
+    ) {
+
+    }
+
+    /**
+     * Runs version check checking the supplied version is approprate for the
+     * project and also whether a more recent version is available
+     * @param applicationVersion version to check
+     * @returns Promise representing outcome - resolves to undefined when
+     * successful and rejects when there is an error
+     */
+    async run (applicationVersion: string) {
+        const isEnvVarSet = (envVarName: string) => envVarName in process.env;
+
+        if (!isEnvVarSet("CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING") &&
+            !this.isSuitableVersionForProject(applicationVersion)) {
+
+            this.logUnsuitableVersion(applicationVersion, this.config.versionSpecification as string);
+
+            return;
+        }
+
+        const runTimeFile = join(this.dataDirectory, "last-version-run-time");
+        const executionTime = Date.now();
+
+        if (!timeWithinThreshold(runTimeFile, executionTime, this.runThresholdDays, ThresholdUnit.DAYS)) {
+            await this.checkCurrentVersionOfCliIsLatest(applicationVersion);
+
+            writeFileSync(
+                runTimeFile,
+                new Date(executionTime).toISOString()
+            );
+        }
+
+    }
+
+    /**
+     * Creates a VersionCheck object ensuring the dataDir is present when it is
+     * absent
+     * @param argumentsObject - containing the properties to create the
+     * VersionCheck object
+     * @returns new VersionCheck object
+     */
+    static create (
+        {
+            dataDirectory,
+            runThresholdDays,
+            logger,
+            config
+        }: CreateArguments
+    ): VersionCheck {
+        if (!existsSync(dataDirectory)) {
+            mkdirSync(dataDirectory, { recursive: true });
+        }
+
+        return new VersionCheck(dataDirectory, runThresholdDays, logger, config);
+    }
+
+    private logUnsuitableVersion (actualVersion: string, requiredVersionSpecification: string) {
+        const sepLine = "-".repeat(80);
+        this.logger.warn(
+            `WARNING: this version: ${actualVersion} does not meet the project requirements: ${requiredVersionSpecification}
+        
+Run:
+
+\tchs-dev sync
+
+to update chs-dev to a suitable version
+${sepLine}
+
+`
+        );
+    };
+
+    private isSuitableVersionForProject (applicationVersion: string): boolean {
+        return !this.config.versionSpecification || satisfies(applicationVersion, this.config.versionSpecification); ;
+    }
+
+    private async checkCurrentVersionOfCliIsLatest (applicationVersion) {
+        const latestVersion = await getLatestReleaseVersion();
+
+        const semverDifference = diff(latestVersion, applicationVersion);
+
+        if (semverDifference !== null) {
+            this.logVersionDifference(latestVersion, applicationVersion, semverDifference);
+        }
+    };
+
+    private logVersionDifference (latestVersion: string, currentVersion: string, semverDifference: string) {
+        const versionDifference: string = semverDifference === "major" || semverDifference === "minor"
+            ? ` ${semverDifference}`
+            : "";
+
+        const sepLine = "=".repeat(80);
+        const versionOutOfDateMessage = `📣 There is a newer${versionDifference} version (${latestVersion}) available (current version: ${currentVersion})
+    
+Run:
+
+\tchs-dev sync
+
+to update to latest version
+`;
+
+        this.logger.info(
+            `${sepLine}\n\n${versionOutOfDateMessage}\n\n${sepLine}`
+        );
+    };
+
+}

--- a/src/run/version-check.ts
+++ b/src/run/version-check.ts
@@ -90,7 +90,7 @@ export class VersionCheck {
         const sepLine = "-".repeat(80);
         this.logger.warn(
             `WARNING: this version: ${actualVersion} does not meet the project requirements: ${requiredVersionSpecification}
-        
+
 Run:
 
 \tchs-dev sync
@@ -123,7 +123,7 @@ ${sepLine}
 
         const sepLine = "=".repeat(80);
         const versionOutOfDateMessage = `📣 There is a newer${versionDifference} version (${latestVersion}) available (current version: ${currentVersion})
-    
+
 Run:
 
 \tchs-dev sync

--- a/test/helpers/vpn-check.spec.ts
+++ b/test/helpers/vpn-check.spec.ts
@@ -1,0 +1,52 @@
+import { expect, jest } from "@jest/globals";
+import { isOnVpn } from "../../src/helpers/vpn-check";
+import childProcess from "child_process";
+
+describe("isOnVpn", () => {
+
+    const execSpy = jest.spyOn(childProcess, "execSync");
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        execSpy.mockReturnValue(Buffer.from("", "utf8"));
+    });
+
+    it("calls exec ping", () => {
+        isOnVpn();
+
+        expect(execSpy).toHaveBeenCalledWith("ping -c 3 websenseproxy.internal.ch");
+    });
+
+    it("returns false when ping fails", () => {
+        execSpy.mockImplementation((_, __) => {
+            throw new Error("Command failed: ping");
+        });
+
+        expect(isOnVpn()).toBe(false);
+    });
+
+    it("returns true when ping succeeds", () => {
+        execSpy.mockReturnValue(Buffer.from(`PING websenseproxy.internal.ch (172.16.200.196): 56 data bytes
+64 bytes from 172.16.200.196: icmp_seq=0 ttl=62 time=16.702 ms
+64 bytes from 172.16.200.196: icmp_seq=1 ttl=62 time=19.661 ms
+64 bytes from 172.16.200.196: icmp_seq=2 ttl=62 time=19.282 ms
+
+--- websenseproxy.internal.ch ping statistics ---
+3 packets transmitted, 3 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = 16.702/18.548/19.661/1.315 ms`, "utf8"));
+
+        expect(isOnVpn()).toBe(true);
+    });
+
+    it("returns false when ping loses all packets", () => {
+        execSpy.mockReturnValue(Buffer.from(`PING websenseproxy.internal.ch (172.16.200.196): 56 data bytes
+
+--- websenseproxy.internal.ch ping statistics ---
+3 packets transmitted, 0 packets received, 100.0% packet loss
+round-trip min/avg/max/stddev = 16.702/18.548/19.661/1.315 ms`, "utf8"));
+
+        expect(isOnVpn()).toBe(false);
+    });
+
+});

--- a/test/run/__snapshots__/version-check.spec.ts.snap
+++ b/test/run/__snapshots__/version-check.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`VersionCheck run first run through displays correct message when the in
 [
   [
     "WARNING: this version: 0.9.23 does not meet the project requirements: >=1.0.0 <2.0.0
-        
+
 Run:
 
 	chs-dev sync
@@ -23,7 +23,7 @@ exports[`VersionCheck run first run through displays correct message when there 
     "================================================================================
 
 📣 There is a newer version (1.1.2) available (current version: 1.1.1)
-    
+
 Run:
 
 	chs-dev sync
@@ -42,7 +42,7 @@ exports[`VersionCheck run first run through displays correct message when there 
     "================================================================================
 
 📣 There is a newer minor version (1.2.0) available (current version: 1.1.1)
-    
+
 Run:
 
 	chs-dev sync
@@ -61,7 +61,7 @@ exports[`VersionCheck run first run through displays correct message when there 
     "================================================================================
 
 📣 There is a newer minor version (1.2.1) available (current version: 1.1.1)
-    
+
 Run:
 
 	chs-dev sync
@@ -80,7 +80,7 @@ exports[`VersionCheck run first run through displays correct message when there 
     "================================================================================
 
 📣 There is a newer major version (2.0.0) available (current version: 1.1.1)
-    
+
 Run:
 
 	chs-dev sync
@@ -99,7 +99,7 @@ exports[`VersionCheck run first run through displays correct message when there 
     "================================================================================
 
 📣 There is a newer major version (2.0.1) available (current version: 1.1.1)
-    
+
 Run:
 
 	chs-dev sync
@@ -118,7 +118,7 @@ exports[`VersionCheck run first run through displays correct message when there 
     "================================================================================
 
 📣 There is a newer major version (2.1.0) available (current version: 1.1.1)
-    
+
 Run:
 
 	chs-dev sync
@@ -135,7 +135,7 @@ exports[`VersionCheck run subsequent run through displays correct message when t
 [
   [
     "WARNING: this version: 0.9.23 does not meet the project requirements: >=1.0.0 <2.0.0
-        
+
 Run:
 
 	chs-dev sync

--- a/test/run/__snapshots__/version-check.spec.ts.snap
+++ b/test/run/__snapshots__/version-check.spec.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`init hook first run through displays correct message when the installed version not meeting project 1`] = `
+exports[`VersionCheck run first run through displays correct message when the installed version not meeting project 1`] = `
 [
   [
     "WARNING: this version: 0.9.23 does not meet the project requirements: >=1.0.0 <2.0.0
-
+        
 Run:
 
 	chs-dev sync
@@ -17,13 +17,13 @@ to update chs-dev to a suitable version
 ]
 `;
 
-exports[`init hook first run through displays correct message when there is newer version: 1.1.2 1`] = `
+exports[`VersionCheck run first run through displays correct message when there is newer version: 1.1.2 1`] = `
 [
   [
     "================================================================================
 
 📣 There is a newer version (1.1.2) available (current version: 1.1.1)
-
+    
 Run:
 
 	chs-dev sync
@@ -36,13 +36,13 @@ to update to latest version
 ]
 `;
 
-exports[`init hook first run through displays correct message when there is newer version: 1.2.0 1`] = `
+exports[`VersionCheck run first run through displays correct message when there is newer version: 1.2.0 1`] = `
 [
   [
     "================================================================================
 
 📣 There is a newer minor version (1.2.0) available (current version: 1.1.1)
-
+    
 Run:
 
 	chs-dev sync
@@ -55,13 +55,13 @@ to update to latest version
 ]
 `;
 
-exports[`init hook first run through displays correct message when there is newer version: 1.2.1 1`] = `
+exports[`VersionCheck run first run through displays correct message when there is newer version: 1.2.1 1`] = `
 [
   [
     "================================================================================
 
 📣 There is a newer minor version (1.2.1) available (current version: 1.1.1)
-
+    
 Run:
 
 	chs-dev sync
@@ -74,13 +74,13 @@ to update to latest version
 ]
 `;
 
-exports[`init hook first run through displays correct message when there is newer version: 2.0.0 1`] = `
+exports[`VersionCheck run first run through displays correct message when there is newer version: 2.0.0 1`] = `
 [
   [
     "================================================================================
 
 📣 There is a newer major version (2.0.0) available (current version: 1.1.1)
-
+    
 Run:
 
 	chs-dev sync
@@ -93,13 +93,13 @@ to update to latest version
 ]
 `;
 
-exports[`init hook first run through displays correct message when there is newer version: 2.0.1 1`] = `
+exports[`VersionCheck run first run through displays correct message when there is newer version: 2.0.1 1`] = `
 [
   [
     "================================================================================
 
 📣 There is a newer major version (2.0.1) available (current version: 1.1.1)
-
+    
 Run:
 
 	chs-dev sync
@@ -112,13 +112,13 @@ to update to latest version
 ]
 `;
 
-exports[`init hook first run through displays correct message when there is newer version: 2.1.0 1`] = `
+exports[`VersionCheck run first run through displays correct message when there is newer version: 2.1.0 1`] = `
 [
   [
     "================================================================================
 
 📣 There is a newer major version (2.1.0) available (current version: 1.1.1)
-
+    
 Run:
 
 	chs-dev sync
@@ -131,11 +131,11 @@ to update to latest version
 ]
 `;
 
-exports[`init hook subsequent run through displays correct message when the installed version not meeting project 1`] = `
+exports[`VersionCheck run subsequent run through displays correct message when the installed version not meeting project 1`] = `
 [
   [
     "WARNING: this version: 0.9.23 does not meet the project requirements: >=1.0.0 <2.0.0
-
+        
 Run:
 
 	chs-dev sync

--- a/test/run/version-check.spec.ts
+++ b/test/run/version-check.spec.ts
@@ -1,0 +1,277 @@
+import { expect, jest } from "@jest/globals";
+import Config from "../../src/model/Config";
+import { VersionCheck } from "../../src/run/version-check";
+import { getLatestReleaseVersion as getLatestReleaseVersionMock } from "../../src/helpers/latest-release";
+import { timeWithinThreshold as timeWithinThresholdMock } from "../../src/helpers/time-within-threshold";
+import fs from "fs";
+import { join } from "path";
+
+jest.mock("../../src/helpers/latest-release");
+jest.mock("../../src/helpers/time-within-threshold");
+
+describe("VersionCheck", () => {
+
+    const projectConfig: Config = {
+        env: {},
+        projectPath: "./docker-project",
+        projectName: "docker-project",
+        authenticatedRepositories: [],
+        versionSpecification: ">=1.0.0 <2.0.0"
+    };
+    const loggerMock = {
+        warn: jest.fn(),
+        info: jest.fn()
+    };
+    const runThresholdDays = 14;
+
+    const existsSyncSpy = jest.spyOn(fs, "existsSync");
+    const mkdirSyncSpy = jest.spyOn(fs, "mkdirSync");
+    const writeFileSyncSpy = jest.spyOn(fs, "writeFileSync");
+    const readFileSyncSpy = jest.spyOn(fs, "readFileSync");
+
+    const dataDir: string = "data/";
+
+    const version = "1.1.1";
+
+    const differentVersionTestCases = [
+        ["1.1.2", `📣 There is a newer version (1.1.2) available (current version: ${version})`],
+        ["1.2.0", `📣 There is a newer minor version (1.2.0) available (current version: ${version})`],
+        ["1.2.1", `📣 There is a newer minor version (1.2.1) available (current version: ${version})`],
+        ["2.0.0", `📣 There is a newer major version (2.0.0) available (current version: ${version})`],
+        ["2.0.1", `📣 There is a newer major version (2.0.1) available (current version: ${version})`],
+        ["2.1.0", `📣 There is a newer major version (2.1.0) available (current version: ${version})`]
+    ];
+
+    describe("create", () => {
+        beforeEach(() => {
+            jest.resetAllMocks();
+
+            mkdirSyncSpy.mockImplementation((_, __) => { });
+        });
+
+        it("checks if data directory exists", () => {
+            VersionCheck.create({
+                dataDirectory: dataDir,
+                logger: loggerMock,
+                config: projectConfig,
+                runThresholdDays
+            });
+
+            expect(existsSyncSpy).toHaveBeenCalledWith(dataDir);
+        });
+
+        it("creates data directory when does not exist already", () => {
+            existsSyncSpy.mockReturnValue(false);
+
+            VersionCheck.create({
+                dataDirectory: dataDir,
+                logger: loggerMock,
+                config: projectConfig,
+                runThresholdDays
+            });
+
+            expect(mkdirSyncSpy).toHaveBeenCalledWith(dataDir, { recursive: true });
+        });
+
+        it("does not create data directory when already present", () => {
+            existsSyncSpy.mockReturnValue(true);
+
+            VersionCheck.create({
+                dataDirectory: dataDir,
+                logger: loggerMock,
+                config: projectConfig,
+                runThresholdDays
+            });
+
+            expect(mkdirSyncSpy).not.toHaveBeenCalled();
+        });
+
+        it("returns a VersionCheck object", () => {
+
+            existsSyncSpy.mockReturnValue(true);
+
+            const result = VersionCheck.create({
+                dataDirectory: dataDir,
+                logger: loggerMock,
+                config: projectConfig,
+                runThresholdDays
+            });
+
+            expect(result).toBeInstanceOf(VersionCheck);
+        });
+    });
+
+    describe("run", () => {
+        let versionCheck: VersionCheck;
+
+        describe("first run through", () => {
+            beforeEach(() => {
+                jest.resetAllMocks();
+
+                existsSyncSpy.mockReturnValueOnce(true);
+
+                versionCheck = VersionCheck.create({
+                    dataDirectory: dataDir,
+                    logger: loggerMock,
+                    config: projectConfig,
+                    runThresholdDays
+                });
+
+                // @ts-expect-error
+                getLatestReleaseVersionMock.mockResolvedValue(version);
+
+                delete process.env.CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING;
+
+                writeFileSyncSpy.mockImplementation((_, __) => { });
+
+                existsSyncSpy.mockReturnValue(false);
+            });
+
+            it("fetches the latest version", async () => {
+
+                await versionCheck.run(version);
+
+                expect(getLatestReleaseVersionMock).toHaveBeenCalled();
+            });
+
+            for (const [newerVersion, expectedMessage] of differentVersionTestCases) {
+                it(`displays correct message when there is newer version: ${newerVersion}`, async () => {
+                    // @ts-expect-error
+                    getLatestReleaseVersionMock.mockResolvedValue(newerVersion);
+
+                    await versionCheck.run(version);
+
+                    expect(loggerMock.info.mock.calls).toMatchSnapshot();
+                });
+            }
+
+            it("displays correct message when the installed version not meeting project", async () => {
+                // @ts-expect-error
+                getLatestReleaseVersionMock.mockResolvedValue("0.9.23");
+
+                await versionCheck.run("0.9.23");
+
+                expect(loggerMock.warn.mock.calls).toMatchSnapshot();
+            });
+        });
+
+        describe("subsequent run through", () => {
+
+            const lastRunThrough = "2024-01-01T00:00:00.000Z";
+
+            let currentTime: Date;
+
+            beforeEach(() => {
+                jest.resetAllMocks();
+
+                existsSyncSpy.mockReturnValue(true);
+
+                versionCheck = VersionCheck.create({
+                    dataDirectory: dataDir,
+                    logger: loggerMock,
+                    config: projectConfig,
+                    runThresholdDays
+                });
+
+                // @ts-expect-error
+                getLatestReleaseVersionMock.mockResolvedValue(version);
+
+                readFileSyncSpy.mockReturnValue(
+                    Buffer.from(
+                        lastRunThrough
+                    )
+                );
+
+                const dateNowMock = jest.fn();
+                dateNowMock.mockImplementation(() => currentTime.getTime());
+
+                // @ts-expect-error
+                Date.now = dateNowMock;
+
+                delete process.env.CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING;
+
+                writeFileSyncSpy.mockImplementation((_, __) => { });
+
+            });
+
+            it("checks version when after time passed", async () => {
+                currentTime = new Date(2024, 0, 16, 0, 0, 0, 0);
+
+                // @ts-expect-error
+                timeWithinThresholdMock.mockReturnValue(false);
+
+                // @ts-expect-error
+                getLatestReleaseVersionMock.mockResolvedValue(version);
+
+                await versionCheck.run(version);
+
+                expect(getLatestReleaseVersionMock).toHaveBeenCalled();
+            });
+
+            it("writes out current time when has checked version", async () => {
+                currentTime = new Date(2024, 0, 16, 0, 0, 0, 0);
+
+                // @ts-expect-error
+                timeWithinThresholdMock.mockReturnValue(false);
+
+                // @ts-expect-error
+                getLatestReleaseVersionMock.mockResolvedValue(version);
+
+                await versionCheck.run(version);
+
+                expect(writeFileSyncSpy).toHaveBeenCalledWith(
+                    join(dataDir, "last-version-run-time"),
+                    "2024-01-16T00:00:00.000Z"
+                );
+            });
+
+            it("does not check version when time passed not passed", async () => {
+                // @ts-expect-error
+                timeWithinThresholdMock.mockReturnValue(true);
+
+                // @ts-expect-error
+                getLatestReleaseVersionMock.mockResolvedValue(version);
+
+                await versionCheck.run(version);
+
+                expect(getLatestReleaseVersionMock).not.toHaveBeenCalled();
+            });
+
+            it("checks version when CHS_DEV_CHECK_VERSION is set", async () => {
+                process.env.CHS_DEV_CHECK_VERSION = "1";
+
+                currentTime = new Date(2024, 0, 13, 0, 0, 0, 0);
+
+                // @ts-expect-error
+                getLatestReleaseVersionMock.mockResolvedValue(version);
+
+                await versionCheck.run(version);
+
+                expect(getLatestReleaseVersionMock).toHaveBeenCalled();
+            });
+
+            it("displays correct message when the installed version not meeting project", async () => {
+            // @ts-expect-error
+                getLatestReleaseVersionMock.mockResolvedValue("0.9.23");
+
+                await versionCheck.run("0.9.23");
+
+                expect(loggerMock.warn.mock.calls).toMatchSnapshot();
+            });
+
+            it("does not display message when the installed version not meeting project and env var set", async () => {
+            // @ts-expect-error
+                getLatestReleaseVersionMock.mockResolvedValue("0.9.23");
+
+                process.env.CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING = "true";
+
+                await versionCheck.run("0.9.23");
+
+                expect(loggerMock.warn).not.toHaveBeenCalled();
+            });
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
* Some actions require connecting to internal resources only available over the VPN or internally
* Refactor init hook extracting the version checking to a separate class