### PR TITLE
Amend logs command to take multiple service names

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomp
 
 ```
 USAGE
-  $ chs-dev compose-logs [SERVICENAME] [-C] [-f] [-n <value>]
+  $ chs-dev compose-logs [SERVICENAME...] [-C] [-f] [-n <value>]
 
 ARGUMENTS
-  SERVICENAME  specify the service name of the logs to follow, when not specified follows aggregated logs
+  SERVICENAME...  specify the service names of the logs to follow, when not specified follows aggregated logs
 
 FLAGS
   -C, --compose       View the compose logs rather than service logs
@@ -395,10 +395,10 @@ ALIASES
 
 ```
 USAGE
-  $ chs-dev logs [SERVICENAME] [-C] [-f] [-n <value>]
+  $ chs-dev logs [SERVICENAME...] [-C] [-f] [-n <value>]
 
 ARGUMENTS
-  SERVICENAME  specify the service name of the logs to follow, when not specified follows aggregated logs
+  SERVICENAME...  specify the service names of the logs to follow, when not specified follows aggregated logs
 
 FLAGS
   -C, --compose       View the compose logs rather than service logs
@@ -469,10 +469,10 @@ ARGUMENTS
 
 ```
 USAGE
-  $ chs-dev service-logs [SERVICENAME] [-C] [-f] [-n <value>]
+  $ chs-dev service-logs [SERVICENAME...] [-C] [-f] [-n <value>]
 
 ARGUMENTS
-  SERVICENAME  specify the service name of the logs to follow, when not specified follows aggregated logs
+  SERVICENAME...  specify the service names of the logs to follow, when not specified follows aggregated logs
 
 FLAGS
   -C, --compose       View the compose logs rather than service logs

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -12,10 +12,13 @@ export default class Logs extends Command {
      */
     static deprecateAliases = true;
 
+    static strict = false;
+
     static args = {
         serviceName: Args.string({
+            name: "serviceNames",
             required: false,
-            description: "specify the service name of the logs to follow, when not specified follows aggregated logs"
+            description: "specify the service names of the logs to follow, when not specified follows aggregated logs"
         })
     };
 
@@ -58,7 +61,7 @@ export default class Logs extends Command {
     }
 
     async run (): Promise<any> {
-        const { args, flags } = await this.parse(Logs);
+        const { argv, flags } = await this.parse(Logs);
 
         if (flags.compose) {
             return await this.composeLogViewer.view({
@@ -68,7 +71,7 @@ export default class Logs extends Command {
         }
 
         const logsArgs = {
-            serviceName: args.serviceName,
+            serviceNames: argv as string[],
             tail: flags.tail,
             follow: flags.follow,
             signal: undefined

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -19,7 +19,7 @@ const CONTAINER_STARTED_HEALTHY_STATUS_PATTERN =
     /(?:Container\s)?([\dA-Za-z-]+)\s*(Started|Healthy|Stopped|Pulling|Pulled)/;
 
 type LogsArgs = {
-    serviceName: string | undefined,
+    serviceNames: string[] | undefined,
     tail: string | undefined,
     follow: boolean | undefined,
     signal: AbortSignal | undefined
@@ -87,12 +87,12 @@ export class DockerCompose {
         );
     }
 
-    logs ({ serviceName, signal, tail, follow }: LogsArgs): Promise<void> {
+    logs ({ serviceNames, signal, tail, follow }: LogsArgs): Promise<void> {
         return this.runDockerCompose([
             "logs",
             ...(tail && tail !== "all" ? ["--tail", tail] : []),
             ...(follow && follow === true ? ["--follow"] : []),
-            ...(serviceName ? ["--", serviceName] : [])
+            ...(serviceNames && serviceNames.length > 0 ? ["--", ...serviceNames] : [])
         ], new LogEverythingLogHandler(this.logger),
         signal);
     }

--- a/test/commands/logs.spec.ts
+++ b/test/commands/logs.spec.ts
@@ -81,15 +81,45 @@ describe("Logs command", () => {
                 compose: false,
                 follow: true,
                 tail: "2"
-            }
+            },
+            argv: [
+                "service-one"
+            ]
         });
 
         await logsCommand.run();
 
         expect(dockerComposeLogsMock).toHaveBeenCalledWith({
-            serviceName: "service-one",
+            serviceNames: ["service-one"],
             tail: "2",
             follow: true
+        });
+    });
+
+    it("follows service logs for multiple services when service names provided", async () => {
+        // @ts-expect-error
+        parseMock.mockResolvedValue({
+            args: {
+                serviceName: "service-one"
+            },
+            flags: {
+                compose: false,
+                follow: true,
+                tail: "2"
+            },
+            argv: [
+                "service-one",
+                "service-two"
+            ]
+        });
+
+        await logsCommand.run();
+
+        expect(dockerComposeLogsMock).toHaveBeenCalledWith({
+            serviceNames: ["service-one", "service-two"],
+            tail: "2",
+            follow: true,
+            signal: undefined
         });
     });
 

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -410,7 +410,7 @@ describe("DockerCompose", () => {
             ], expectedSpawnOptions);
         });
 
-        it("runs docker compose logs with service when supplied", async () => {
+        it("runs docker compose logs with services when supplied", async () => {
             mockOnce.mockImplementation((type, listener) => {
                 if (type === "exit") {
                     // @ts-expect-error
@@ -418,7 +418,7 @@ describe("DockerCompose", () => {
                 }
             });
 
-            await dockerCompose.logs({ serviceName: "service-one" });
+            await dockerCompose.logs({ serviceNames: ["service-one", "service-two"] });
 
             const expectedSpawnOptions = {
                 logHandler: { handle: mockLogEverythingLogHandle },
@@ -437,7 +437,8 @@ describe("DockerCompose", () => {
                 "compose",
                 "logs",
                 "--",
-                "service-one"
+                "service-one",
+                "service-two"
             ], expectedSpawnOptions);
         });
         it("rejects when code is not 0 or 130", async () => {
@@ -454,7 +455,7 @@ describe("DockerCompose", () => {
                 }
             });
 
-            await dockerCompose.logs({ serviceName: "service-one", tail: "10" });
+            await dockerCompose.logs({ serviceNames: ["service-one"], tail: "10" });
 
             expect(spawnMock).toHaveBeenCalledWith("docker", [
                 "compose",
@@ -474,7 +475,7 @@ describe("DockerCompose", () => {
                 }
             });
 
-            await dockerCompose.logs({ serviceName: "service-one", follow: true });
+            await dockerCompose.logs({ serviceNames: ["service-one"], follow: true });
 
             expect(spawnMock).toHaveBeenCalledWith("docker", [
                 "compose",


### PR DESCRIPTION
* Turns out you can specify multiple services to follow the logs of, this helps developing distributed apps to see the information flow around the environment. This was suggested by John Cook
