### PR TITLE
Exit with error from docker login when no profile

### DIFF
--- a/bin/docker_login.sh
+++ b/bin/docker_login.sh
@@ -110,12 +110,14 @@ for required_repo in "${repository_urls[@]}"; do
           docker login --username AWS --password-stdin "${required_repo}"
         break
       else
-        profile="$(grep -E "^${required_account}\s" | head -n1 | cut -d' ' -f3)"
+        profile="$(grep -E "^${required_account}\s" "${profile_mapping_file}" | head -n1 | cut -d' ' -f3)"
 
         if [[ -z "${profile}" ]]; then
           printf -- 'Could not find profile for '%s' you are going to have to configure one using "aws configure sso"\n' "${required_account}" >&2
 
           exit 1
+        else
+          break
         fi
       fi
     done

--- a/bin/docker_login.sh
+++ b/bin/docker_login.sh
@@ -111,6 +111,12 @@ for required_repo in "${repository_urls[@]}"; do
         break
       else
         profile="$(grep -E "^${required_account}\s" | head -n1 | cut -d' ' -f3)"
+
+        if [[ -z "${profile}" ]]; then
+          printf -- 'Could not find profile for '%s' you are going to have to configure one using "aws configure sso"\n' "${required_account}" >&2
+
+          exit 1
+        fi
       fi
     done
   fi


### PR DESCRIPTION
* Currently docker login script will indefinitely loop when there is no profile found for a given account, now it will print an error and exit with an error exit status
