### PR TITLE
Split out commands which have been deprecated rather than use aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ $ npm install -g chs-dev
 $ chs-dev COMMAND
 running command...
 $ chs-dev (--version)
-chs-dev/1.1.0 darwin-arm64 node-v20.10.0
+chs-dev/1.2.0 darwin-arm64 node-v20.10.0
 $ chs-dev --help [COMMAND]
 USAGE
   $ chs-dev COMMAND
@@ -152,7 +152,6 @@ USAGE
 
 <!-- commands -->
 * [`chs-dev autocomplete [SHELL]`](#chs-dev-autocomplete-shell)
-* [`chs-dev compose-logs [SERVICENAME]`](#chs-dev-compose-logs-servicename)
 * [`chs-dev development disable SERVICES`](#chs-dev-development-disable-services)
 * [`chs-dev development enable SERVICES`](#chs-dev-development-enable-services)
 * [`chs-dev development services`](#chs-dev-development-services)
@@ -168,7 +167,6 @@ USAGE
 * [`chs-dev modules disable MODULES`](#chs-dev-modules-disable-modules)
 * [`chs-dev modules enable MODULES`](#chs-dev-modules-enable-modules)
 * [`chs-dev reload SERVICE`](#chs-dev-reload-service)
-* [`chs-dev service-logs [SERVICENAME]`](#chs-dev-service-logs-servicename)
 * [`chs-dev services available`](#chs-dev-services-available)
 * [`chs-dev services disable SERVICES`](#chs-dev-services-disable-services)
 * [`chs-dev services enable SERVICES`](#chs-dev-services-enable-services)
@@ -204,30 +202,6 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v0.2.1/src/commands/autocomplete/index.ts)_
-
-## `chs-dev compose-logs [SERVICENAME]`
-
-Outputs the logs for services and compose logs (i.e. logs from 'up' and 'down' commands)
-
-```
-USAGE
-  $ chs-dev compose-logs [SERVICENAME...] [-C] [-f] [-n <value>]
-
-ARGUMENTS
-  SERVICENAME...  specify the service names of the logs to follow, when not specified follows aggregated logs
-
-FLAGS
-  -C, --compose       View the compose logs rather than service logs
-  -f, --follow        Follow the logs
-  -n, --tail=<value>  [default: all] Number of lines from the end of the logs
-
-DESCRIPTION
-  Outputs the logs for services and compose logs (i.e. logs from 'up' and 'down' commands)
-
-ALIASES
-  $ chs-dev service-logs
-  $ chs-dev compose-logs
-```
 
 ## `chs-dev development disable SERVICES`
 
@@ -415,9 +389,34 @@ FLAGS
 DESCRIPTION
   Outputs the logs for services and compose logs (i.e. logs from 'up' and 'down' commands)
 
-ALIASES
-  $ chs-dev service-logs
-  $ chs-dev compose-logs
+EXAMPLES
+  view all aggregated service logs
+
+    $ chs-dev logs
+
+  follow aggregated service logs
+
+    $ chs-dev logs -f
+
+  follow logs for service
+
+    $ chs-dev logs service-one service-two -f
+
+  load the last line in the aggregated service logs
+
+    $ chs-dev logs -n 1
+
+  view all compose logs
+
+    $ chs-dev logs -C
+
+  follow compose logs
+
+    $ chs-dev logs -C -f
+
+  load the last line in the compose logs
+
+    $ chs-dev logs -C -n 1
 ```
 
 ## `chs-dev modules available`
@@ -478,30 +477,6 @@ ARGUMENTS
 
 DESCRIPTION
   Rebuilds and restarts the supplied service running in development mode to load in any changes to source code
-```
-
-## `chs-dev service-logs [SERVICENAME]`
-
-Outputs the logs for services and compose logs (i.e. logs from 'up' and 'down' commands)
-
-```
-USAGE
-  $ chs-dev service-logs [SERVICENAME...] [-C] [-f] [-n <value>]
-
-ARGUMENTS
-  SERVICENAME...  specify the service names of the logs to follow, when not specified follows aggregated logs
-
-FLAGS
-  -C, --compose       View the compose logs rather than service logs
-  -f, --follow        Follow the logs
-  -n, --tail=<value>  [default: all] Number of lines from the end of the logs
-
-DESCRIPTION
-  Outputs the logs for services and compose logs (i.e. logs from 'up' and 'down' commands)
-
-ALIASES
-  $ chs-dev service-logs
-  $ chs-dev compose-logs
 ```
 
 ## `chs-dev services available`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chs-dev",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chs-dev",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/confirm": "^3.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chs-dev",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Damian Dunajski (ddunajski@companieshouse.gov.uk)",
   "bin": {
     "chs-dev": "./bin/run.js"

--- a/src/commands/deprecated/compose-logs.ts
+++ b/src/commands/deprecated/compose-logs.ts
@@ -1,0 +1,34 @@
+import { Command } from "@oclif/core";
+
+export default class ComposeLogs extends Command {
+
+    static description = "This command is DEPRECATED, use logs -C instead";
+
+    static hidden = true;
+
+    static examples = [
+        {
+            description: "view all compose logs",
+            command: "<%= config.bin %> <%= command.id %> -C"
+        },
+        {
+            description: "follow compose logs",
+            command: "<%= config.bin %> <%= command.id %> -C -f"
+        },
+        {
+            description: "load the last line in the compose logs",
+            command: "<%= config.bin %> <%= command.id %> -C -n 1"
+        }
+    ];
+
+    run (): Promise<any> {
+        return this.error(
+            "This command has been removed in favour of `logs -C`", {
+                suggestions: [
+                    "run chs-dev logs -C"
+                ]
+            }
+        );
+    }
+
+}

--- a/src/commands/deprecated/service-logs.ts
+++ b/src/commands/deprecated/service-logs.ts
@@ -1,0 +1,38 @@
+import { Command } from "@oclif/core";
+
+export default class ServiceLogs extends Command {
+
+    static description = "This command is DEPRECATED, use logs instead";
+
+    static hidden = true;
+
+    static examples = [
+        {
+            description: "view all aggregated logs",
+            command: "<%= config.bin %> <%= command.id %> logs"
+        },
+        {
+            description: "follow aggregated logs",
+            command: "<%= config.bin %> <%= command.id %> -f"
+        },
+        {
+            description: "follow logs for service",
+            command: "<%= config.bin %> <%= command.id %> -f service-one service-two"
+        },
+        {
+            description: "load the last line in the aggregated logs",
+            command: "<%= config.bin %> <%= command.id %> -n 1"
+        }
+    ];
+
+    run (): Promise<any> {
+        return this.error(
+            "This command has been removed in favour of `logs`", {
+                suggestions: [
+                    "run chs-dev logs"
+                ]
+            }
+        );
+    }
+
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -16,6 +16,8 @@ import ServiceDisable from "./services/disable.js";
 import ModulesAvailable from "./modules/available.js";
 import ModulesEnable from "./modules/enable.js";
 import ModulesDisable from "./modules/disable.js";
+import ComposeLogs from "./deprecated/compose-logs.js";
+import ServiceLogs from "./deprecated/service-logs.js";
 
 export const commands = {
     down: Down,
@@ -24,6 +26,7 @@ export const commands = {
     up: Up,
     sync: Sync,
     logs: Logs,
+    "compose-logs": ComposeLogs,
     "exclusions:list": ExclusionsList,
     "exclusions:add": ExclusionsAdd,
     "exclusions:remove": ExclusionsRemove,
@@ -35,7 +38,8 @@ export const commands = {
     "services:disable": ServiceDisable,
     "modules:available": ModulesAvailable,
     "modules:enable": ModulesEnable,
-    "modules:disable": ModulesDisable
+    "modules:disable": ModulesDisable,
+    "service-logs": ServiceLogs
 };
 
 export default commands;

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -6,14 +6,6 @@ import { ComposeLogViewer } from "../run/compose-log-viewer.js";
 export default class Logs extends Command {
     static description = "Outputs the logs for services and compose logs (i.e. logs from 'up' and 'down' commands)";
 
-    static aliases: string[] = ["service-logs", "compose-logs"];
-
-    /**
-     * Show deprecation message when aliases are used and prompt the user to
-     * use correct command
-     */
-    static deprecateAliases = true;
-
     static strict = false;
 
     static args = {
@@ -46,6 +38,37 @@ export default class Logs extends Command {
             description: "Number of lines from the end of the logs"
         })
     };
+
+    static examples = [
+        {
+            description: "view all aggregated service logs",
+            command: "<%= config.bin %> <%= command.id %>"
+        },
+        {
+            description: "follow aggregated service logs",
+            command: "<%= config.bin %> <%= command.id %> -f"
+        },
+        {
+            description: "follow logs for service",
+            command: "<%= config.bin %> <%= command.id %> service-one service-two -f"
+        },
+        {
+            description: "load the last line in the aggregated service logs",
+            command: "<%= config.bin %> <%= command.id %> -n 1"
+        },
+        {
+            description: "view all compose logs",
+            command: "<%= config.bin %> <%= command.id %> -C"
+        },
+        {
+            description: "follow compose logs",
+            command: "<%= config.bin %> <%= command.id %> -C -f"
+        },
+        {
+            description: "load the last line in the compose logs",
+            command: "<%= config.bin %> <%= command.id %> -C -n 1"
+        }
+    ];
 
     private dockerCompose: DockerCompose;
     private composeLogViewer: ComposeLogViewer;


### PR DESCRIPTION
* Remove aliases from logs
* Create commands ServiceLogs and ComposeLogs to replace aliases and print out deprecation message
