### PR TITLE
Add ability to configure project directory via an Env Var

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,8 @@ within the current working directory.
 
 #### Environment variables
 
+* `CHS_DEV_PROJECT` - specifies the directory containing the project files to
+  use to provision the environment
 * `CHS_DEV_CHECK_VERSION` - when set will check the version is correct
   regardless of when it was previously run
 * `CHS_DEV_FORCE_ECR_CHECK` - when set will always run ECR login before running

--- a/src/commands/AbstractStateModificationCommand.ts
+++ b/src/commands/AbstractStateModificationCommand.ts
@@ -1,6 +1,8 @@
 import { Command, Config } from "@oclif/core";
 import { Inventory } from "../state/inventory.js";
 import { StateManager } from "../state/state-manager.js";
+import ChsDevConfig from "../model/Config.js";
+import loadConfig from "../helpers/config-loader.js";
 
 type ArgumentValidationPredicate = (argument: string) => boolean;
 type ValidArgumentHandler = (argument: string) => Promise<void>;
@@ -19,12 +21,15 @@ export default abstract class AbstractStateModificationCommand extends Command {
 
     protected argumentValidationPredicate: ArgumentValidationPredicate = defaultValidationPredicate;
     protected validArgumentHandler: ValidArgumentHandler = defaultValidArgumentHandler;
+    protected chsDevConfig: ChsDevConfig;
 
     constructor (argv: string[], config: Config, stateModificationObjectType: "service" | "module") {
         super(argv, config);
 
-        this.inventory = new Inventory(process.cwd(), config.cacheDir);
-        this.stateManager = new StateManager(process.cwd());
+        this.chsDevConfig = loadConfig();
+
+        this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
+        this.stateManager = new StateManager(this.chsDevConfig.projectPath);
         this.stateModificationObjectType = stateModificationObjectType;
     }
 

--- a/src/commands/development/enable.ts
+++ b/src/commands/development/enable.ts
@@ -40,9 +40,9 @@ export default class Enable extends AbstractStateModificationCommand {
     private async cloneServiceRepository (serviceName: string): Promise<void> {
         const service = this.inventory.services.find(item => item.name === serviceName) as Service;
 
-        const localPath = join(process.cwd(), "repositories", service.name);
+        const localPath = join(this.chsDevConfig.projectPath, "repositories", service.name);
         if (!existsSync(localPath)) {
-            ux.action.start(`Cloning ${service.repository!.branch || "default"} branch of ${service.repository!.url} repository to ${relative(process.cwd(), localPath)} directory`);
+            ux.action.start(`Cloning ${service.repository!.branch || "default"} branch of ${service.repository!.url} repository to ${relative(this.chsDevConfig.projectPath, localPath)} directory`);
             // @ts-ignore
             const git = simpleGit();
 

--- a/src/commands/development/services.ts
+++ b/src/commands/development/services.ts
@@ -1,5 +1,7 @@
 import { Command, Config, Flags } from "@oclif/core";
 import { Inventory } from "../../state/inventory.js";
+import ChsDevConfig from "../../model/Config.js";
+import loadConfig from "../../helpers/config-loader.js";
 
 export default class Services extends Command {
 
@@ -18,10 +20,14 @@ export default class Services extends Command {
         })
     };
 
+    private chsDevConfig: ChsDevConfig;
+
     constructor (argv: string[], config: Config) {
         super(argv, config);
 
-        this.inventory = new Inventory(process.cwd(), config.cacheDir);
+        this.chsDevConfig = loadConfig();
+
+        this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
 
     }
 

--- a/src/commands/development/services.ts
+++ b/src/commands/development/services.ts
@@ -7,8 +7,6 @@ export default class Services extends Command {
 
     static description = "Lists all services which are available to enable in development mode";
 
-    private readonly inventory: Inventory;
-
     static flags = {
         json: Flags.boolean({
             name: "json",
@@ -20,7 +18,8 @@ export default class Services extends Command {
         })
     };
 
-    private chsDevConfig: ChsDevConfig;
+    private readonly inventory: Inventory;
+    private readonly chsDevConfig: ChsDevConfig;
 
     constructor (argv: string[], config: Config) {
         super(argv, config);

--- a/src/commands/exclusions/list.ts
+++ b/src/commands/exclusions/list.ts
@@ -1,5 +1,7 @@
 import { Command, Config, Flags } from "@oclif/core";
 import { StateManager } from "../../state/state-manager.js";
+import ChsDevConfig from "../../model/Config.js";
+import loadConfig from "../../helpers/config-loader.js";
 
 export default class List extends Command {
 
@@ -17,11 +19,14 @@ export default class List extends Command {
     };
 
     private readonly stateManager: StateManager;
+    private readonly chsDevConfig: ChsDevConfig;
 
     constructor (argv: string[], config: Config) {
         super(argv, config);
 
-        this.stateManager = new StateManager(process.cwd());
+        this.chsDevConfig = loadConfig();
+
+        this.stateManager = new StateManager(this.chsDevConfig.projectPath);
     }
 
     async run (): Promise<any> {

--- a/src/commands/modules/available.ts
+++ b/src/commands/modules/available.ts
@@ -1,5 +1,7 @@
 import { Command, Config, Flags } from "@oclif/core";
 import { Inventory } from "../../state/inventory.js";
+import ChsDevConfig from "../../model/Config.js";
+import loadConfig from "../../helpers/config-loader.js";
 
 export default class Available extends Command {
     static description = "Lists the available modules";
@@ -16,12 +18,15 @@ export default class Available extends Command {
     };
 
     private readonly inventory: Inventory;
+    private readonly chsDevConfig: ChsDevConfig;
 
     constructor (argv: string[], config: Config) {
         super(argv, config);
 
+        this.chsDevConfig = loadConfig();
+
         this.inventory = new Inventory(
-            process.cwd(), config.cacheDir
+            this.chsDevConfig.projectPath, config.cacheDir
         );
 
     }

--- a/src/commands/reload.ts
+++ b/src/commands/reload.ts
@@ -3,6 +3,8 @@ import { Inventory } from "../state/inventory.js";
 import { join } from "path";
 import fsExtra from "fs-extra";
 import { DependencyCache } from "../run/dependency-cache.js";
+import ChsDevConfig from "../model/Config.js";
+import loadConfig from "../helpers/config-loader.js";
 
 export default class Reload extends Command {
 
@@ -18,11 +20,15 @@ export default class Reload extends Command {
 
     private readonly inventory: Inventory;
     private readonly dependencyCache: DependencyCache;
+    private readonly chsDevConfig: ChsDevConfig;
 
     constructor (argv: string[], config: Config) {
         super(argv, config);
-        this.inventory = new Inventory(process.cwd(), config.cacheDir);
-        this.dependencyCache = new DependencyCache(process.cwd());
+
+        this.chsDevConfig = loadConfig();
+
+        this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
+        this.dependencyCache = new DependencyCache(this.chsDevConfig.projectPath);
     }
 
     async run (): Promise<any> {
@@ -31,7 +37,7 @@ export default class Reload extends Command {
         const serviceName: string = args.service;
 
         if (this.isServiceValid(serviceName)) {
-            const touchFile = join(process.cwd(), "local", serviceName, ".touch");
+            const touchFile = join(this.chsDevConfig.projectPath, "local", serviceName, ".touch");
 
             this.dependencyCache.update();
 

--- a/src/commands/services/available.ts
+++ b/src/commands/services/available.ts
@@ -1,5 +1,7 @@
 import { Command, Config, Flags } from "@oclif/core";
 import { Inventory } from "../../state/inventory.js";
+import ChsDevConfig from "../../model/Config.js";
+import loadConfig from "../../helpers/config-loader.js";
 
 export default class Available extends Command {
 
@@ -17,11 +19,14 @@ export default class Available extends Command {
     };
 
     private readonly inventory: Inventory;
+    private readonly chsDevConfig: ChsDevConfig;
 
     constructor (argv: string[], config: Config) {
         super(argv, config);
 
-        this.inventory = new Inventory(process.cwd(), config.cacheDir);
+        this.chsDevConfig = loadConfig();
+
+        this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
     }
 
     async run (): Promise<any> {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,6 +7,7 @@ import { collect, deduplicate } from "../helpers/array-reducers.js";
 import { DockerCompose } from "../run/docker-compose.js";
 import loadConfig from "../helpers/config-loader.js";
 import State from "../model/State.js";
+import ChsDevConfig from "../model/Config.js";
 
 export default class Status extends Command {
     static description = "print status of an environment";
@@ -32,11 +33,14 @@ export default class Status extends Command {
 
     private dockerCompose: DockerCompose;
 
+    private chsDevConfig: ChsDevConfig;
+
     constructor (argv: string[], config: Config) {
         super(argv, config);
-        this.inventory = new Inventory(process.cwd(), config.cacheDir);
-        this.stateManager = new StateManager(process.cwd());
-        this.dockerCompose = new DockerCompose(loadConfig(), {
+        this.chsDevConfig = loadConfig();
+        this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
+        this.stateManager = new StateManager(this.chsDevConfig.projectPath);
+        this.dockerCompose = new DockerCompose(this.chsDevConfig, {
             log: (msg: string) => this.log(msg)
         });
     }

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -40,9 +40,9 @@ export default class Up extends Command {
 
         this.dockerCompose = new DockerCompose(this.chsDevConfig, logger);
 
-        this.stateManager = new StateManager(process.cwd());
-        this.dependencyCache = new DependencyCache(process.cwd());
-        this.developmentMode = new DevelopmentMode(this.dockerCompose, process.cwd());
+        this.stateManager = new StateManager(this.chsDevConfig.projectPath);
+        this.dependencyCache = new DependencyCache(this.chsDevConfig.projectPath);
+        this.developmentMode = new DevelopmentMode(this.dockerCompose, this.chsDevConfig.projectPath);
         this.composeLogViewer = new ComposeLogViewer(this.chsDevConfig, logger);
         this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
         this.permanentRepositories = new PermanentRepositories(this.chsDevConfig, this.inventory);

--- a/src/helpers/config-loader.ts
+++ b/src/helpers/config-loader.ts
@@ -12,7 +12,7 @@ const DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD = 8;
  * @returns Project Config
  */
 export const load: () => Config = () => {
-    const projectPath = process.cwd();
+    const projectPath = process.env.CHS_DEV_PROJECT || process.cwd();
     const confFile = join(projectPath, "chs-dev/config.yaml");
 
     let config: Partial<Config> = {};

--- a/src/hooks/generate-development-docker-compose.ts
+++ b/src/hooks/generate-development-docker-compose.ts
@@ -3,10 +3,12 @@ import { join } from "path";
 import { Inventory } from "../state/inventory.js";
 import { DockerComposeFileGenerator } from "../generator/docker-compose-file-generator.js";
 import { IConfig } from "@oclif/config";
+import loadConfig from "../helpers/config-loader.js";
 
 // @ts-ignore
 export const hook: Hook<"generate-development-docker-compose"> = async function ({ serviceName, config }: { serviceName: string; config: IConfig }) {
-    const path = process.cwd();
+    const chsDevConfig = loadConfig();
+    const path = chsDevConfig.projectPath;
     const inventory = new Inventory(path, config.cacheDir);
     const dockerComposeFileGenerator = new DockerComposeFileGenerator(path);
     const service = inventory.services.find(service => service.name === serviceName);

--- a/src/hooks/generate-runnable-docker-compose.ts
+++ b/src/hooks/generate-runnable-docker-compose.ts
@@ -5,9 +5,11 @@ import { StateManager } from "../state/state-manager.js";
 import { DockerComposeFileGenerator } from "../generator/docker-compose-file-generator.js";
 import { TiltfileGenerator } from "../generator/tiltfile-generator.js";
 import { ServiceLoader } from "../run/service-loader.js";
+import loadConfig from "../helpers/config-loader.js";
 
 export const hook: Hook<"generate-runnable-docker-compose"> = async function (options) {
-    const path = process.cwd();
+    const chsDevConfig = loadConfig();
+    const path = chsDevConfig.projectPath;
     const inventory = new Inventory(path, options.config.cacheDir);
     const stateManager = new StateManager(path);
     const dockerComposeFileGenerator = new DockerComposeFileGenerator(path);

--- a/test/commands/development/enable.spec.ts
+++ b/test/commands/development/enable.spec.ts
@@ -6,7 +6,14 @@ import simpleGitMock from "simple-git";
 import { join } from "path";
 
 const includeServiceInLiveUpdateMock = jest.fn();
+const loadConfigMock = jest.fn();
 let snapshot;
+
+jest.mock("../../../src/helpers/config-loader", () => {
+    return function () {
+        return loadConfigMock();
+    };
+});
 
 jest.mock("../../../src/state/inventory", () => {
     return {
@@ -46,6 +53,10 @@ describe("development enable", () => {
     beforeEach(() => {
         jest.resetAllMocks();
 
+        loadConfigMock.mockReturnValue({
+            projectPath: projectDir
+        });
+
         developmentEnable = new Enable(
             // @ts-expect-error
             [], { cacheDir: "./caches", runHook: runHookMock } as Config
@@ -55,7 +66,6 @@ describe("development enable", () => {
         developmentEnable.parse = parseMock;
         // @ts-expect-error
         developmentEnable.error = errorMock;
-
         cwdSpy.mockReturnValue(projectDir);
 
         // @ts-expect-error

--- a/test/commands/exclusions/list.spec.ts
+++ b/test/commands/exclusions/list.spec.ts
@@ -2,6 +2,16 @@ import { expect, jest } from "@jest/globals";
 import { Config } from "@oclif/core";
 import List from "../../../src/commands/exclusions/list";
 
+const loadConfigMock = jest.fn();
+
+jest.mock("../../../src/helpers/config-loader", () => {
+    return function () {
+        return {
+            default: loadConfigMock
+        };
+    };
+});
+
 jest.mock("../../../src/state/state-manager", () => {
     return {
         StateManager: function () {
@@ -32,6 +42,9 @@ describe("exclusions list", () => {
             [], {} as Config
         );
 
+        loadConfigMock.mockReturnValue({
+            projectPath: "./project"
+        });
         logMock = jest.spyOn(exclusionsList, "log");
         logJsonMock = jest.spyOn(exclusionsList, "logJson");
         parseMock = jest.spyOn(exclusionsList, "parse");

--- a/test/helpers/config-loader.spec.ts
+++ b/test/helpers/config-loader.spec.ts
@@ -12,6 +12,10 @@ describe("load", () => {
 
     const pwd = "/users/user/docker-chs";
 
+    const originalProcessEnv = {
+        ...process.env
+    };
+
     const fileSystem = {
         "~/.file-one": "foo bar",
         "./file-two.csv": "foo,bar\nbar,foo\n",
@@ -22,6 +26,8 @@ describe("load", () => {
         jest.resetAllMocks();
 
         pwdMock.mockReturnValue(pwd);
+
+        process.env = originalProcessEnv;
     });
 
     it("returns empty configuration when no configuration file exists", () => {
@@ -122,5 +128,18 @@ describe("load", () => {
             authenticatedRepositories: [],
             versionSpecification: ">1.0 <2.0"
         });
+    });
+
+    it("can load project path from CHS_DEV_PROJECT environment var", () => {
+        const chsDevProjectPath = "/users/user/chs-docker-project";
+
+        process.env = {
+            ...process.env,
+            CHS_DEV_PROJECT: chsDevProjectPath
+        };
+
+        existsSyncMock.mockReturnValue(false);
+
+        expect(load()).toEqual({ projectName: "chs-docker-project", env: {}, projectPath: chsDevProjectPath, authenticatedRepositories: [] });
     });
 });


### PR DESCRIPTION
* Add 'CHS_DEV_PROJECT' environment variable which can be used to set the project path
  so that it can be used globally against same project
* Use CHS Dev Configuration to reference projectPath since the config loader resolves this
