### PR TITLE
Fix issue when updating the dependency cache and no maven artefacts

### DIFF
--- a/src/run/dependency-cache.ts
+++ b/src/run/dependency-cache.ts
@@ -1,7 +1,12 @@
 import { execSync } from "child_process";
 import { existsSync, mkdirSync } from "fs";
 import { join } from "path";
+import { homedir } from "os";
 
+/**
+ * Represents local dependencies of software components (i.e. Maven artifacts)
+ * cached for speedier builds.
+ */
 export class DependencyCache {
 
     constructor (private readonly path: string) {
@@ -12,9 +17,25 @@ export class DependencyCache {
         }
     }
 
+    /**
+     * Updates/creates the dependency cache. If there are no cached artifacts
+     * and the cache does not exist, it creates an empty cache.
+     */
     update (): void {
-        execSync(
-            `rsync -au "\${HOME}"/.m2/repository/uk/ "${this.path}"/local/.m2/uk/`
-        );
+        const sourceDirectory = ".m2/repository/uk";
+        const destinationDirectory = join(this.path, "local/.m2/uk/");
+
+        if (existsSync(join(homedir(), sourceDirectory))) {
+            execSync(
+                `rsync -au "\${HOME}"/.m2/repository/uk/ "${destinationDirectory}"`
+            );
+        } else if (!existsSync(destinationDirectory)) {
+            mkdirSync(
+                destinationDirectory,
+                {
+                    recursive: true
+                }
+            );
+        }
     }
 }

--- a/test/run/dependency-cache.spec.ts
+++ b/test/run/dependency-cache.spec.ts
@@ -43,8 +43,36 @@ describe("DependencyCache", () => {
         cache.update();
 
         expect(execSyncMock).toHaveBeenCalledWith(
-            `rsync -au "\${HOME}"/.m2/repository/uk/ "/home/user/project"/local/.m2/uk/`
+            `rsync -au "\${HOME}"/.m2/repository/uk/ "/home/user/project/local/.m2/uk/"`
         );
     });
 
+    it("makes directory only if maven cache does not exist", () => {
+        existsSyncMock.mockReturnValueOnce(true)
+            .mockReturnValue(false);
+
+        const cache = new DependencyCache("/home/user/project");
+
+        cache.update();
+
+        expect(mkdirSyncMock).toHaveBeenCalledWith("/home/user/project/local/.m2/uk/", {
+            recursive: true
+        });
+
+        expect(execSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("does nothing if cache exists and no maven cache", () => {
+        existsSyncMock.mockReturnValueOnce(true)
+            .mockReturnValueOnce(false)
+            .mockReturnValue(true);
+
+        const cache = new DependencyCache("/home/user/project");
+
+        cache.update();
+
+        expect(mkdirSyncMock).not.toHaveBeenCalled();
+
+        expect(execSyncMock).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
* Currently rsync will fail and cause application to not start if the source directory
  (${HOME}/.m2/repository/uk) does not exist, therefore this change will fix the
  behaviour.
