### PR TITLE
Reduce log messages when not on VPN

### DIFF
--- a/src/helpers/vpn-check.ts
+++ b/src/helpers/vpn-check.ts
@@ -23,7 +23,7 @@ export const isOnVpn = () => {
         }
 
     } catch (error) {
-        console.error(error);
+        console.error(`Error occurred when checking VPN Status: ${(error as Error).message}`);
     }
     return false;
 };


### PR DESCRIPTION
* When console.error(error) was called it logged out a lot of information obscuring the actual error logs
