### PR TITLE
Update service-loader to handle missing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chs-dev",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chs-dev",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/confirm": "^3.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chs-dev",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Damian Dunajski (ddunajski@companieshouse.gov.uk)",
   "bin": {
     "chs-dev": "./bin/run.js"

--- a/src/run/service-loader.ts
+++ b/src/run/service-loader.ts
@@ -47,7 +47,12 @@ export class ServiceLoader {
             .flatMap(service => service.dependsOn)
             .reduce(deduplicate, [])
             .filter(serviceName => !loadedServices.some(service => service.name === serviceName))
-            .map(serviceName => this.findService(serviceName) as Service)
+            .map(serviceName => this.findService(serviceName))
+            .filter(service => {
+                return typeof service !== "undefined";
+            })
+            // wont be undefined as filtered out above
+            // @ts-expect-error
             .map(withLiveUpdate);
 
         return [

--- a/test/run/__snapshots__/service-loader.spec.ts.snap
+++ b/test/run/__snapshots__/service-loader.spec.ts.snap
@@ -111,6 +111,7 @@ exports[`ServiceLoader loads modules, no services enabled, none in dev mode 1`] 
       "service-six",
       "service-seven",
       "service-eight",
+      "service-eleven",
     ],
     "liveUpdate": false,
     "metadata": {},

--- a/test/run/service-loader.spec.ts
+++ b/test/run/service-loader.spec.ts
@@ -129,7 +129,8 @@ const serviceNine = {
         "service-five",
         "service-six",
         "service-seven",
-        "service-eight"
+        "service-eight",
+        "service-eleven"
     ],
     repository: null,
     builder: "",


### PR DESCRIPTION
* `ingress-proxy` is a dependency on some services however will not be found in inventory
  as it is part of the default docker-compose file therefore will be undefined when searched
  for. However, this caused a silent failure whereby the docker-compose file was not generated
  due to an error
* Add `service-eleven` as a dependency of a service to service loader tests to add test case for this bug
