### PR TITLE
Append `secrets` property to builder services when service requires it

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,8 @@ are referenced by chs-dev for the given purposes:
 * `chs.local.builder.outputDir` - specifies the value for `OUTDIR` on the
   builder build arg. Typically for node applications which do not build to
   standard output directory of `dist`.
+* `chs.local.builder.requiresSecrets` - when set to `true` will apply all the
+  secrets defined in the docker compose spec to the builder service
 * `chs.local.entrypoint` - specifies the entrypoint script for a given service
   typically for a node application which does not have a
   `ecs-image-buid/docker_start.sh` file

--- a/src/generator/development/spec-assembly/builder-secrets-spec-assembly-function.ts
+++ b/src/generator/development/spec-assembly/builder-secrets-spec-assembly-function.ts
@@ -1,0 +1,31 @@
+import getInitialDockerComposeFile from "../../../helpers/initial-docker-compose-file.js";
+import CONSTANTS from "../../../model/Constants.js";
+import { SpecAssemblyFunction } from "./spec-assembly-function.js";
+
+const builderSecretsSpecAssemblyFunction: SpecAssemblyFunction = (
+    developmentDockerComposeSpec,
+    {
+        projectPath,
+        service
+    }
+) => {
+    if (service.metadata.secretsRequired === CONSTANTS.BOOLEAN_LABEL_TRUE_VALUE) {
+        const dockerComposeSpec = getInitialDockerComposeFile(projectPath);
+
+        if (typeof dockerComposeSpec.secrets !== "undefined") {
+            for (const secretName of Object.keys(dockerComposeSpec.secrets)) {
+                if (typeof developmentDockerComposeSpec.services[`${service.name}-builder`].secrets === "undefined") {
+                    developmentDockerComposeSpec.services[`${service.name}-builder`].secrets = [];
+                }
+
+                // When it was previously unset is set above
+                // @ts-expect-error
+                developmentDockerComposeSpec.services[`${service.name}-builder`].secrets.push(
+                    secretName
+                );
+            }
+        }
+    }
+};
+
+export default builderSecretsSpecAssemblyFunction;

--- a/src/generator/development/spec-assembly/index.ts
+++ b/src/generator/development/spec-assembly/index.ts
@@ -1,5 +1,6 @@
 import { DockerComposeSpec } from "../../../model/DockerComposeSpec.js";
 import buildArgsSpecAssemblyFunction from "./build-args-spec-assembly-function.js";
+import builderSecretsSpecAssemblyFunction from "./builder-secrets-spec-assembly-function.js";
 import builderSpecAssemblyFunction from "./builder-spec-assembly-function.js";
 import dependsOnSpecAssemblyFunction from "./depends-on-spec-assembly-function.js";
 import { simpleSpecAssemblyFunctionFactory } from "./simple-spec-assembly-function.js";
@@ -17,7 +18,8 @@ const specAssemblyFunctions: SpecAssemblyFunction[] = [
     builderSpecAssemblyFunction,
     dependsOnSpecAssemblyFunction,
     ...specFieldsWhichAreImmutable.map(simpleSpecAssemblyFunctionFactory),
-    buildArgsSpecAssemblyFunction
+    buildArgsSpecAssemblyFunction,
+    builderSecretsSpecAssemblyFunction
 ];
 
 /**

--- a/src/generator/docker-compose-file-generator.ts
+++ b/src/generator/docker-compose-file-generator.ts
@@ -7,6 +7,7 @@ import { readFileSync, existsSync, mkdirSync } from "fs";
 import { deduplicate } from "../helpers/array-reducers.js";
 import { getBuilder } from "../state/builders.js";
 import DevelopmentDockerComposeSpecFactory from "./development/development-docker-compose-factory.js";
+import getInitialDockerComposeFile from "../helpers/initial-docker-compose-file.js";
 
 interface LiveUpdate {
   liveUpdate: boolean;
@@ -20,9 +21,7 @@ export class DockerComposeFileGenerator extends AbstractFileGenerator {
     }
 
     generateDockerComposeFile (services: ServiceWithLiveUpdate[], excluded: string[] | undefined) {
-        const initialDockerComposeFile = join(this.path, "services/infrastructure/docker-compose.yaml");
-
-        const dockerCompose = yaml.parse(readFileSync(initialDockerComposeFile).toString("utf-8"));
+        const dockerCompose = getInitialDockerComposeFile(this.path);
 
         // Remove any excluded services (if supplied)
         const runnableServices = typeof excluded !== "undefined"

--- a/src/helpers/initial-docker-compose-file.ts
+++ b/src/helpers/initial-docker-compose-file.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import yaml from "yaml";
+import CONSTANTS from "../model/Constants.js";
+import { DockerComposeSpec } from "../model/DockerComposeSpec.js";
+
+const getInitialDockerComposeFile = (path: string): DockerComposeSpec => {
+    return yaml.parse(
+        readFileSync(join(path, CONSTANTS.BASE_DOCKER_COMPOSE_FILE), "utf8").toString()
+    );
+};
+
+export default getInitialDockerComposeFile;

--- a/src/model/Constants.ts
+++ b/src/model/Constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Constant values for chs-dev projects
+ */
+export const CONSTANTS = {
+    /**
+     * The initial Docker Compose Spec which forms the basis of the generated
+     * Docker Compose specification defining the environment
+     */
+    BASE_DOCKER_COMPOSE_FILE: "services/infrastructure/docker-compose.yaml",
+
+    /**
+     * Value for a boolean label to be considered true
+     */
+    BOOLEAN_LABEL_TRUE_VALUE: "true"
+};
+
+export default CONSTANTS;

--- a/src/model/DockerComposeSpec.ts
+++ b/src/model/DockerComposeSpec.ts
@@ -1,3 +1,9 @@
+type Secret = {
+    environment: string
+} | {
+    file: string
+}
+
 /**
  * Represents the Docker Compose Spec file when read in from yaml
  */
@@ -10,6 +16,9 @@ export type DockerComposeSpec = {
             build?: Record<string, any>,
             env_file?: string | string[],
             depends_on?: string[] | Record<string, Record<string, any>>
+            secrets?: string[] | Record<string, any>
         } & Record<string, any>
-    }
+    },
+    secrets?: Record<string, Secret>,
+    include?: string[]
 };

--- a/src/state/service-reader.ts
+++ b/src/state/service-reader.ts
@@ -40,6 +40,7 @@ const metadataLabelMapping = {
     dockerfile: "chs.local.dockerfile",
     entrypoint: "chs.local.entrypoint",
     buildOutputDir: "chs.local.builder.outputDir",
+    secretsRequired: "chs.local.builder.requiresSecrets",
     repositoryRequired: "chs.local.repositoryRequired"
 };
 

--- a/test/data/service-reader/modules/module-one/simple-service.docker-compose.yaml
+++ b/test/data/service-reader/modules/module-one/simple-service.docker-compose.yaml
@@ -3,6 +3,9 @@ services:
     labels:
       - chs.description=simple service
       - chs.repository.url=git@github.com/companieshouse/repo.git
+      - chs.local.builder=node
+      - chs.local.builder.requiresSecrets=true
+      - chs.local.builder.languageVersion=18
     image: some-service-api
     ports:
       - 12345

--- a/test/generator/development/spec-assembly/builder-secrets-spec-assembly-functions.spec.ts
+++ b/test/generator/development/spec-assembly/builder-secrets-spec-assembly-functions.spec.ts
@@ -1,0 +1,194 @@
+import { expect, jest } from "@jest/globals";
+import fs from "fs";
+import { DockerComposeSpec } from "../../../../src/model/DockerComposeSpec";
+
+import { services } from "../../../utils/data";
+import builderSecretsSpecAssemblyFunction from "../../../../src/generator/development/spec-assembly/builder-secrets-spec-assembly-function";
+import yaml from "yaml";
+import { join } from "path";
+import CONSTANTS from "../../../../src/model/Constants";
+import Service from "../../../../src/model/Service";
+
+describe("builderSecretsSpecAssemblyFunction", () => {
+    const readFileSyncSpy = jest.spyOn(fs, "readFileSync");
+
+    let service: Service;
+    let developmentDockerComposeSpec: DockerComposeSpec;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        service = services[0];
+        developmentDockerComposeSpec = {
+            services: {
+                [`${service.name}-builder`]: {},
+                [service.name]: {}
+            }
+        };
+
+        delete service.metadata.secretsRequired;
+    });
+
+    it("reads in initial docker compose file", () => {
+        service.metadata.secretsRequired = "true";
+
+        readFileSyncSpy.mockReturnValue(Buffer.from(yaml.stringify({
+            secrets: {
+                "secret-one": {
+                    environment: "ENV_VAR_ONE"
+                },
+                "secret-two": {
+                    file: "./file.txt"
+                }
+            }
+        }), "utf-8"));
+
+        builderSecretsSpecAssemblyFunction(developmentDockerComposeSpec, {
+            service,
+            projectPath: "/home/testuser/docker-c",
+            serviceDockerComposeSpec: {
+                services: {}
+            },
+            builderDockerComposeSpec: {
+                builderSpec: "",
+                name: "",
+                version: ""
+            }
+        });
+
+        expect(readFileSyncSpy).toHaveBeenCalledWith(
+            join("/home/testuser/docker-c", CONSTANTS.BASE_DOCKER_COMPOSE_FILE),
+            "utf8"
+        );
+    });
+
+    it("adds secrets to builder when service defines requiresSecrets", () => {
+        service.metadata.secretsRequired = "true";
+
+        readFileSyncSpy.mockReturnValue(Buffer.from(yaml.stringify({
+            secrets: {
+                "secret-one": {
+                    environment: "ENV_VAR_ONE"
+                },
+                "secret-two": {
+                    file: "./file.txt"
+                }
+            }
+        }), "utf-8"));
+
+        builderSecretsSpecAssemblyFunction(developmentDockerComposeSpec, {
+            service,
+            projectPath: "/home/testuser/docker-c",
+            serviceDockerComposeSpec: {
+                services: {}
+            },
+            builderDockerComposeSpec: {
+                builderSpec: "",
+                name: "",
+                version: ""
+            }
+        });
+
+        expect(developmentDockerComposeSpec.services[`${service.name}-builder`].secrets)
+            .toEqual([
+                "secret-one",
+                "secret-two"
+            ]);
+    });
+
+    it("does not set secrets when there are no secrets in initial docker compose", () => {
+        service.metadata.secretsRequired = "true";
+
+        readFileSyncSpy.mockReturnValue(Buffer.from(yaml.stringify({ }), "utf-8"));
+
+        builderSecretsSpecAssemblyFunction(developmentDockerComposeSpec, {
+            service,
+            projectPath: "/home/testuser/docker-c",
+            serviceDockerComposeSpec: {
+                services: {}
+            },
+            builderDockerComposeSpec: {
+                builderSpec: "",
+                name: "",
+                version: ""
+            }
+        });
+
+        expect(developmentDockerComposeSpec.services[`${service.name}-builder`].secrets).toBeUndefined();
+    });
+
+    it("does not set secrets on main service", () => {
+        service.metadata.secretsRequired = "true";
+
+        readFileSyncSpy.mockReturnValue(Buffer.from(yaml.stringify({
+            secrets: {
+                "secret-one": {
+                    environment: "ENV_VAR_ONE"
+                },
+                "secret-two": {
+                    file: "./file.txt"
+                }
+            }
+        }), "utf-8"));
+
+        builderSecretsSpecAssemblyFunction(developmentDockerComposeSpec, {
+            service,
+            projectPath: "/home/testuser/docker-c",
+            serviceDockerComposeSpec: {
+                services: {}
+            },
+            builderDockerComposeSpec: {
+                builderSpec: "",
+                name: "",
+                version: ""
+            }
+        });
+
+        expect(developmentDockerComposeSpec.services[service.name].secrets).toBeUndefined();
+    });
+
+    it("does not set secrets when secretsRequired not set", () => {
+        readFileSyncSpy.mockReturnValue(Buffer.from(yaml.stringify({
+            secrets: {
+                "secret-one": {
+                    environment: "ENV_VAR_ONE"
+                },
+                "secret-two": {
+                    file: "./file.txt"
+                }
+            }
+        }), "utf-8"));
+
+        builderSecretsSpecAssemblyFunction(developmentDockerComposeSpec, {
+            service,
+            projectPath: "/home/testuser/docker-c",
+            serviceDockerComposeSpec: {
+                services: {}
+            },
+            builderDockerComposeSpec: {
+                builderSpec: "",
+                name: "",
+                version: ""
+            }
+        });
+
+        expect(developmentDockerComposeSpec.services[`${service.name}-builder`].secrets).toBeUndefined();
+    });
+
+    it("does not read spec in when secrets not required", () => {
+        builderSecretsSpecAssemblyFunction(developmentDockerComposeSpec, {
+            service,
+            projectPath: "/home/testuser/docker-c",
+            serviceDockerComposeSpec: {
+                services: {}
+            },
+            builderDockerComposeSpec: {
+                builderSpec: "",
+                name: "",
+                version: ""
+            }
+        });
+
+        expect(readFileSyncSpy).not.toHaveBeenCalled();
+    });
+});

--- a/test/state/__snapshots__/service-reader.spec.ts.snap
+++ b/test/state/__snapshots__/service-reader.spec.ts.snap
@@ -27,13 +27,15 @@ exports[`readServices loads a more complicated 1`] = `
 exports[`readServices loads a simple service 1`] = `
 [
   {
-    "builder": "",
+    "builder": "node",
     "dependsOn": [
       "mongo",
     ],
     "description": "simple service",
     "metadata": {
       "healthcheck": undefined,
+      "languageMajorVersion": "18",
+      "secretsRequired": "true",
     },
     "module": "module-one",
     "name": "simple-service",

--- a/test/utils/data.ts
+++ b/test/utils/data.ts
@@ -1,4 +1,6 @@
-export const services = [
+import Service from "../../src/model/Service";
+
+export const services: Service[] = [
     {
         name: "service-one",
         description: "A Service for one and for all",


### PR DESCRIPTION
* It is more secure to use Docker Compose secret's management offered by the
  secrets top level element and secrets array on a service
* These secrets are mounted within the `/run/secrets/` directory within
  the container and are not viewable in the logs or Docker Console
