### PR TITLE
Synchronise services in development mode's specs on up

### DIFF
--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -71,6 +71,10 @@ export default class Up extends Command {
             });
         }
 
+        ux.action.start("Synchronising current services in development mode with inventory");
+        await this.synchroniseServicesInDevelopmentMode();
+        ux.action.stop();
+
         ux.action.start("Ensuring all permanent repos are up to date");
         await this.permanentRepositories.ensureAllExistAndAreUpToDate();
         ux.action.stop();
@@ -123,5 +127,13 @@ export default class Up extends Command {
 
                 return typeof service !== "undefined";
             });
+    }
+
+    private async synchroniseServicesInDevelopmentMode (): Promise<any> {
+        for (const serviceInDevelopmentMode of this.stateManager.snapshot.servicesWithLiveUpdate) {
+            await this.config.runHook("generate-development-docker-compose", {
+                serviceName: serviceInDevelopmentMode
+            });
+        }
     }
 }

--- a/src/generator/file-generator.ts
+++ b/src/generator/file-generator.ts
@@ -8,6 +8,9 @@ export abstract class AbstractFileGenerator {
     protected constructor (protected path: string, protected fileName: string) {}
 
     protected writeFile (lines: string[], joinChar: string = EOL + EOL, fileName = this.fileName) {
-        writeFileSync(join(this.path, fileName), ["# DO NOT MODIFY THIS FILE MANUALLY", ...lines].join(joinChar));
+        writeFileSync(join(this.path, fileName), [
+            "# DO NOT MODIFY THIS FILE MANUALLY - this file is generated automatically and changes may be lost",
+            ...lines
+        ].join(joinChar));
     }
 }

--- a/test/commands/up.spec.ts
+++ b/test/commands/up.spec.ts
@@ -244,6 +244,16 @@ describe("Up command", () => {
             });
         });
 
+        it("should synchronise local docker compose specs for services in development mode", async () => {
+            await up.run();
+
+            expect(runHookMock).toHaveBeenCalledWith(
+                "generate-development-docker-compose", {
+                    serviceName: SERVICES_IN_DEV_MODE.servicesWithLiveUpdate[0]
+                }
+            );
+        });
+
     });
 
     describe("services in live update are not enabled", () => {
@@ -276,5 +286,14 @@ describe("Up command", () => {
         await expect(up.run()).rejects.toEqual(expect.anything());
 
         expect(dockerComposeUpMock).not.toHaveBeenCalled();
+    });
+
+    it("should not run generate-development-docker-compose hook", async () => {
+        await up.run();
+
+        expect(runHookMock).not.toHaveBeenCalledWith(
+            "generate-development-docker-compose",
+            expect.anything()
+        );
     });
 });


### PR DESCRIPTION
* Services in inventory may digress to what the development docker compose spec is so regenerate when running up
