### PR TITLE
Add --no-verify-ssl to get-caller-identity calls

### DIFF
--- a/bin/docker_login.sh
+++ b/bin/docker_login.sh
@@ -67,7 +67,7 @@ if [[ ! -f "${profile_mapping_file}" || -n "${recreate_profile_mapping}" ]]; the
     # Handle SSO profiles and login if necessary
     if [[ -n "${sso_account_id}" ]]; then
       while : ""; do
-        account_id="$(aws sts get-caller-identity --query Account --output text --profile "${profile}")"
+        account_id="$(aws sts get-caller-identity --query Account --output text --profile "${profile}" --no-verify-ssl)"
 
         if [[ -n "${account_id}" ]]; then
           region="$(aws configure get region --profile "${profile}")"
@@ -79,7 +79,7 @@ if [[ ! -f "${profile_mapping_file}" || -n "${recreate_profile_mapping}" ]]; the
       done
     else
       # otherwise assume the user has configured AWS access for profile with access keys
-      account_id="$(aws sts get-caller-identity --query Account --output text --profile "${profile}")"
+      account_id="$(aws sts get-caller-identity --query Account --output text --profile "${profile}" --no-verify-ssl)"
 
       if [[ -n "${account_id}" ]]; then
         region="$(aws configure get region --profile "${profile}")"


### PR DESCRIPTION
* Sometimes calls to get-caller-identity may fail when on VPN due to
  self signed certificates on Proxy Server which causen the login to
  go into indefinite loop
