### PR TITLE
Services may have other attributes which should be copied across

### DIFF
--- a/src/generator/development/spec-assembly/index.ts
+++ b/src/generator/development/spec-assembly/index.ts
@@ -4,6 +4,7 @@ import builderSecretsSpecAssemblyFunction from "./builder-secrets-spec-assembly-
 import builderSpecAssemblyFunction from "./builder-spec-assembly-function.js";
 import dependsOnSpecAssemblyFunction from "./depends-on-spec-assembly-function.js";
 import envFileSpecAssemblyFunction from "./env-file-assembly-function.js";
+import nonServiceTlaSpecAssemblyFunction from "./non-services-tla-spec-assembly-function.js";
 import { simpleSpecAssemblyFunctionFactory } from "./simple-spec-assembly-function.js";
 import { SpecAssemblyFunction, SpecAssemblyFunctionOptions } from "./spec-assembly-function.js";
 
@@ -14,7 +15,10 @@ const specFieldsWhichAreImmutable = [
     "image",
     "healthcheck",
     "ports",
-    "expose"
+    "expose",
+    "dns",
+    "dns_search",
+    "volumes"
 ];
 
 const specAssemblyFunctions: SpecAssemblyFunction[] = [
@@ -23,7 +27,8 @@ const specAssemblyFunctions: SpecAssemblyFunction[] = [
     ...specFieldsWhichAreImmutable.map(simpleSpecAssemblyFunctionFactory),
     buildArgsSpecAssemblyFunction,
     envFileSpecAssemblyFunction,
-    builderSecretsSpecAssemblyFunction
+    builderSecretsSpecAssemblyFunction,
+    nonServiceTlaSpecAssemblyFunction
 ];
 
 /**

--- a/src/generator/development/spec-assembly/non-services-tla-spec-assembly-function.ts
+++ b/src/generator/development/spec-assembly/non-services-tla-spec-assembly-function.ts
@@ -1,0 +1,18 @@
+import { SpecAssemblyFunction } from "./spec-assembly-function.js";
+
+export const nonServiceTlaSpecAssemblyFunction: SpecAssemblyFunction = (
+    developmentDockerComposeSpec,
+    {
+        serviceDockerComposeSpec
+    }
+) => {
+
+    const nonServicesAttributeKeys = Object.keys(serviceDockerComposeSpec)
+        .filter(attributeName => attributeName !== "services");
+
+    for (const nonServicesAttribute of nonServicesAttributeKeys) {
+        developmentDockerComposeSpec[nonServicesAttribute] = serviceDockerComposeSpec[nonServicesAttribute];
+    }
+};
+
+export default nonServiceTlaSpecAssemblyFunction;

--- a/src/model/DockerComposeSpec.ts
+++ b/src/model/DockerComposeSpec.ts
@@ -20,5 +20,7 @@ export type DockerComposeSpec = {
         } & Record<string, any>
     },
     secrets?: Record<string, Secret>,
-    include?: string[]
+    include?: string[],
+    networks?: Record<string, any>,
+    volumes?: Record<string, any>
 };

--- a/test/generator/development/spec-assembly/non-services-tla-spec-assembly-function.spec.ts
+++ b/test/generator/development/spec-assembly/non-services-tla-spec-assembly-function.spec.ts
@@ -1,0 +1,73 @@
+import { DockerComposeSpec } from "../../../../src/model/DockerComposeSpec.js";
+import { services } from "../../../utils/data.js";
+import { generateBuilderSpec, generateServiceSpec } from "../../../utils/docker-compose-spec.js";
+
+import nonServiceTlaSpecAssemblyFunction from "../../../../src/generator/development/spec-assembly/non-services-tla-spec-assembly-function.js";
+import { expect } from "@jest/globals";
+
+describe("nonServiceTlaSpecAssemblyFunction", () => {
+
+    it("applies non-services attributes from source service to development spec", () => {
+        const service = services[0];
+        const serviceSpec: DockerComposeSpec = {
+            ...generateServiceSpec(service),
+            networks: {
+                "network-one": {},
+                "network-two": {
+                    "some-attribute": "foobar"
+                }
+            },
+            volumes: {
+                "vol-one": {
+                    external: true
+                }
+            },
+            secrets: {
+                secretOne: {
+                    environment: "Secret"
+                }
+            },
+            include: [
+                "file.docker.compose.yaml"
+            ]
+        };
+
+        const developmentDockerComposeSpec = {
+            services: {
+                [service.name]: {
+                    labels: [
+                        "label.one.value=foobar"
+                    ]
+                }
+            }
+        };
+
+        nonServiceTlaSpecAssemblyFunction(
+            developmentDockerComposeSpec,
+            {
+                projectPath: "/tmp/project",
+                service,
+                serviceDockerComposeSpec: serviceSpec,
+                builderDockerComposeSpec: {
+                    name: "java",
+                    version: "v2",
+                    builderSpec: generateBuilderSpec(
+                        "local/builders/java/v2", true
+                    )
+                }
+            }
+        );
+
+        expect(Object.keys(developmentDockerComposeSpec).sort()).toEqual([
+            "networks",
+            "secrets",
+            "services",
+            "volumes",
+            "include"
+        ].sort());
+
+        expect(developmentDockerComposeSpec.services[service.name].labels).toEqual([
+            "label.one.value=foobar"
+        ]);
+    });
+});


### PR DESCRIPTION
* CHIPS failed to run in development mode since the original spec created a volune
  which was missing now it didn't copy across the service
