### PR TITLE
Rotate log file daily rather than each time run

### DIFF
--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -41,8 +41,10 @@ export class DockerCompose {
             );
         }
 
+        const date = new Date(Date.now());
+
         this.logFile = join(logsDir,
-            `compose.out.${Math.floor(Date.now() / 1000)}.txt`);
+            `compose.out.${date.getFullYear()}-${date.getMonth()}-${date.getDay()}.txt`);
     }
 
     down (options?: {

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -122,7 +122,7 @@ describe("DockerCompose", () => {
 
             const dockerCompose = new DockerCompose(config, logger);
 
-            expect(dockerCompose.logFile).toBe("local/.logs/compose.out.1706745600.txt");
+            expect(dockerCompose.logFile).toBe("local/.logs/compose.out.2024-1-4.txt");
         });
     });
 


### PR DESCRIPTION
* To simplify log retrieval and ux of running `chs-dev logs -C` create a log file each day
