### PR TITLE
Apply `pull_policy` to default builder

### DIFF
--- a/src/state/builders.ts
+++ b/src/state/builders.ts
@@ -53,6 +53,7 @@ export const clearBuilders = () => {
 const repositoryBuilderSpec = yaml.stringify({
     services: {
         "<service>": {
+            pull_policy: "build",
             build: {
                 context: "<absolute_repository_path>",
                 args: {

--- a/test/state/builders.spec.ts
+++ b/test/state/builders.spec.ts
@@ -129,6 +129,7 @@ describe("getBuilder", () => {
         const expectedBuilderSpec = yaml.stringify({
             services: {
                 "<service>": {
+                    pull_policy: "build",
                     build: {
                         context: "<absolute_repository_path>",
                         args: {
@@ -173,6 +174,7 @@ describe("getBuilder", () => {
             const expectedBuilderSpec = yaml.stringify({
                 services: {
                     "<service>": {
+                        pull_policy: "build",
                         build: {
                             context: "<absolute_repository_path>",
                             args: {


### PR DESCRIPTION
* Since services in development mode should not be pulled rather built use `pull_policy` to instruct
  docker compose to build rather than pull the image. This ensures that services which do not have ECR
  repositories can still be run in local ECS environment when they are enabled in development mode
