### PR TITLE
Add service name into error message when does not exist

### DIFF
--- a/src/hooks/generate-development-docker-compose.ts
+++ b/src/hooks/generate-development-docker-compose.ts
@@ -14,7 +14,7 @@ export const hook: Hook<"generate-development-docker-compose"> = async function 
     const service = inventory.services.find(service => service.name === serviceName && !service.source.includes("tilt/"));
 
     if (typeof service === "undefined") {
-        return this.error("Cannot create development compose file for a service that does not exist.");
+        return this.error(`Cannot create development compose file for the service: ${serviceName} since it does not exist.`);
     }
 
     try {


### PR DESCRIPTION
* Add service name to error when generating a development docker compose file, this is called on up so the error may be ambiguous if people have services in their state files which do not exist
