### PR TITLE
Add ability to use the Dockerfile in repository with builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,10 @@ are referenced by chs-dev for the given purposes:
   standard output directory of `dist`.
 * `chs.local.builder.requiresSecrets` - when set to `true` will apply all the
   secrets defined in the docker compose spec to the builder service
+* `chs.local.builder.useServiceDockerfile` - when set to `true` will us the
+  Dockerfile for the service rather than the one provided by the builder. The
+  equivalent of merging repository builder with one of the builders within the
+  repository.
 * `chs.local.entrypoint` - specifies the entrypoint script for a given service
   typically for a node application which does not have a
   `ecs-image-buid/docker_start.sh` file

--- a/src/state/service-reader.ts
+++ b/src/state/service-reader.ts
@@ -41,7 +41,8 @@ const metadataLabelMapping = {
     entrypoint: "chs.local.entrypoint",
     buildOutputDir: "chs.local.builder.outputDir",
     secretsRequired: "chs.local.builder.requiresSecrets",
-    repositoryRequired: "chs.local.repositoryRequired"
+    repositoryRequired: "chs.local.repositoryRequired",
+    builderUseServiceDockerFile: "chs.local.builder.useServiceDockerfile"
 };
 
 const readService: (module: string, source: string, serviceName: string, service: ServiceDefinition) => Partial<Service> = (module, source, serviceName, service) => ({

--- a/test/data/service-reader/modules/module-three/another-atypical.docker-compose.yaml
+++ b/test/data/service-reader/modules/module-three/another-atypical.docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       - chs.local.builder.languageVersion=20
       - chs.local.entrypoint=docker_start.sh
       - chs.local.builder.outputDir=out/
+      - chs.local.builder.useServiceDockerfile=true
     image: some-service-api
     ports:
       - 12345

--- a/test/generator/development/spec-assembly/__snapshots__/builder-spec-assembly-function.spec.ts.snap
+++ b/test/generator/development/spec-assembly/__snapshots__/builder-spec-assembly-function.spec.ts.snap
@@ -190,3 +190,80 @@ exports[`builderSpecAssemblyFunction can handle setting repository context for r
   },
 }
 `;
+
+exports[`builderSpecAssemblyFunction can handle using builder and service dockerfile 1`] = `
+{
+  "build": {
+    "context": "/home/test/user/projects/docker-project/repositories/service-one",
+  },
+  "depends_on": {
+    "service-one-builder": {
+      "condition": "service_completed_successfully",
+      "restart": true,
+    },
+  },
+  "volumes": [
+    "repositories/service-one/target:/opt/",
+  ],
+}
+`;
+
+exports[`builderSpecAssemblyFunction can handle using builder and service dockerfile 2`] = `
+{
+  "build": {
+    "context": "/home/test/user/projects/docker-project",
+    "dockerfile": "local/builders/java/v2/build.Dockerfile",
+  },
+  "develop": {
+    "watch": [
+      {
+        "action": "rebuild",
+        "path": ".touch",
+      },
+    ],
+  },
+  "volumes": [
+    "repositories/service-one:/app/",
+    "./out:/opt/out",
+  ],
+}
+`;
+
+exports[`builderSpecAssemblyFunction can handle using builder and service dockerfile appending custom context and dockerfile 1`] = `
+{
+  "build": {
+    "context": "/home/test/user/projects/docker-project/repositories/service-one/another-dir/",
+    "dockerfile": "another.Dockerfile",
+  },
+  "depends_on": {
+    "service-one-builder": {
+      "condition": "service_completed_successfully",
+      "restart": true,
+    },
+  },
+  "volumes": [
+    "repositories/service-one/target:/opt/",
+  ],
+}
+`;
+
+exports[`builderSpecAssemblyFunction can handle using builder and service dockerfile appending custom context and dockerfile 2`] = `
+{
+  "build": {
+    "context": "/home/test/user/projects/docker-project",
+    "dockerfile": "local/builders/java/v2/build.Dockerfile",
+  },
+  "develop": {
+    "watch": [
+      {
+        "action": "rebuild",
+        "path": ".touch",
+      },
+    ],
+  },
+  "volumes": [
+    "repositories/service-one:/app/",
+    "./out:/opt/out",
+  ],
+}
+`;

--- a/test/state/__snapshots__/service-reader.spec.ts.snap
+++ b/test/state/__snapshots__/service-reader.spec.ts.snap
@@ -89,6 +89,7 @@ exports[`readServices loads atypical with entrypoint and outdir 1`] = `
     "description": "simple service",
     "metadata": {
       "buildOutputDir": "out/",
+      "builderUseServiceDockerFile": "true",
       "entrypoint": "docker_start.sh",
       "healthcheck": undefined,
       "languageMajorVersion": "20",


### PR DESCRIPTION
* Add support for label "chs.local.builder.useServiceDockerfile" which will instruct chs-dev to use the Dockerfile within the repository for the service rather than the Dockerfile supplied by the builder
