### PR TITLE
Fix issues with docker login using new l_docker command

### DIFF
--- a/bin/docker_login.sh
+++ b/bin/docker_login.sh
@@ -44,10 +44,16 @@ function install_l_docker() {
   case "${install_y_n}" in
   y | Y)
     if git clone -- git@github.com:companieshouse/dev-env-setup "${dev_env_setup_dir}"; then
+
       if "${dev_env_setup_dir}"/scripts/aws/setup_aws_profiles --install; then
+
+        # If the user has l_aws installed chances are they will have a former version of l_docker
+        # which needs to be removed since it is not compatible with this script
         if command -v l_aws >/dev/null 2>&1; then
+
           if ! reinstall_l_aws "${dev_env_setup_dir}"; then
-            printf -- 'Could not remove former l_docker command. You may have to do this separately\n' >&2
+
+            printf -- 'Encountered an error reinstalling the updated l_aws command therefore could not remove former l_docker command. You may have to do this separately\n' >&2
             return 1
           fi
         fi
@@ -74,10 +80,12 @@ if [[ ! -f "${l_docker_script}" ]]; then
   install_l_docker || exit $?
 fi
 
+# Check that the expected group 'dev' exists otherwise fallback on the default
+# group
 if "${l_docker_script}" -l | grep -q "Group ${dev_group_name}"; then
-  "${l_docker_script}" -g "${dev_group_name}"
+  "${l_docker_script}" -g "${dev_group_name}" || exit $?
 else
   printf -- 'Unexpected setup discovered, using default profile group to login\n'
 
-  "${l_docker_script}"
+  "${l_docker_script}" || exit $?
 fi

--- a/bin/docker_login.sh
+++ b/bin/docker_login.sh
@@ -9,7 +9,8 @@ shell_files=(
   "${HOME}"/.companies_house_config/easy_aws_docker_login.sh
 )
 
-ecr_repo_pattern="([[:digit:]]+)\.dkr\.ecr\.([^.]+)\.amazonaws.com"
+dev_group_name=dev
+l_docker_script="${HOME}"/.ch_dev/bin/l_docker
 
 # Source all the user's shell files
 for shell_file in "${shell_files[@]}"; do
@@ -19,107 +20,64 @@ for shell_file in "${shell_files[@]}"; do
   fi
 done
 
-command -v l_aws >/dev/null 2>&1 || function l_aws() {
-  while getopts 'p:' opt; do
-    case "${opt}" in
-    p) profile="${OPTARG}" ;;
-    *) printf -- 'Unknown arg\n' >&2 ;;
-    esac
-  done
+function reinstall_l_aws() {
+  local dev_env_setup_dir="$1"
 
-  : "${profile:?profile required}"
+  "${dev_env_setup_dir}"/scripts/aws/setup_aws_sso_login_util --install --auto
 
-  aws sso login --profile "${profile}"
+  return $?
 }
 
-repository_urls=("$@")
+function install_l_docker() {
+  printf -- 'Does not look like the required utility: l_docker is installed on your local machine.\n'
+  printf -- 'Do you want to install it? \n'
+  printf -- '-- Answer y/n\n'
 
-# Create companies house config directory should it not exist
-companies_house_configuration_directory="${HOME}"/.chs-dev/var
+  local dev_env_setup_dir
+  dev_env_setup_dir="$(mktemp -d)"
 
-if [[ ! -d "${companies_house_configuration_directory}" ]]; then
-  mkdir -p "${companies_house_configuration_directory}"
-fi
+  trap 'rm -rf "${dev_env_setup_dir}"' RETURN
 
-profile_mapping_file="${companies_house_configuration_directory}"/aws_account_profile_mapping
+  read -n 1 -r install_y_n
+  printf -- '\n'
 
-aws_profiles="$(aws configure list-profiles --output text)"
-
-if [[ -f "${profile_mapping_file}" ]]; then
-  # Load profiles and check that each has an entry in the profile mapping
-  # if not trigger the recreation of the profile mapping file
-
-  if ! xargs -I % grep -q % "${profile_mapping_file}" <<<"${aws_profiles}"; then
-    printf -- 'Profile mapping missing profiles, will recreate...\n'
-    recreate_profile_mapping=true
-  fi
-fi
-
-if [[ ! -f "${profile_mapping_file}" || -n "${recreate_profile_mapping}" ]]; then
-  # Remove the old mapping file
-  [[ -f "${profile_mapping_file}" ]] && rm "${profile_mapping_file}"
-
-  # Iteratively process profile retrieving its account details and output to
-  # mapping  file
-  while read -r profile; do
-    sso_account_id="$(aws configure get sso_account_id --profile "${profile}")"
-
-    # Handle SSO profiles and login if necessary
-    if [[ -n "${sso_account_id}" ]]; then
-      while : ""; do
-        account_id="$(aws sts get-caller-identity --query Account --output text --profile "${profile}" --no-verify-ssl)"
-
-        if [[ -n "${account_id}" ]]; then
-          region="$(aws configure get region --profile "${profile}")"
-          printf -- '%s %s %s\n' "${account_id}" "${region}" "${profile}" >>"${profile_mapping_file}"
-          break
-        else
-          l_aws -p "${profile}"
+  case "${install_y_n}" in
+  y | Y)
+    if git clone -- git@github.com:companieshouse/dev-env-setup "${dev_env_setup_dir}"; then
+      if "${dev_env_setup_dir}"/scripts/aws/setup_aws_profiles --install; then
+        if command -v l_aws >/dev/null 2>&1; then
+          if ! reinstall_l_aws "${dev_env_setup_dir}"; then
+            printf -- 'Could not remove former l_docker command. You may have to do this separately\n' >&2
+            return 1
+          fi
         fi
-      done
+
+      else
+        printf -- 'There was an error installing l_docker and aws profiles - try manually running this before trying again\n' >&2
+        return 1
+      fi
     else
-      # otherwise assume the user has configured AWS access for profile with access keys
-      account_id="$(aws sts get-caller-identity --query Account --output text --profile "${profile}" --no-verify-ssl)"
-
-      if [[ -n "${account_id}" ]]; then
-        region="$(aws configure get region --profile "${profile}")"
-        printf -- '%s %s %s\n' "${account_id}" "${region}" "${profile}" >>"${profile_mapping_file}"
-      else
-        printf -- 'Cannot determine account id for profile %s are the keys correct?\n' "${profile}" >&2
-      fi
-
+      # shellcheck disable=SC2016
+      printf -- 'Could not clone dev-env-setup. Run `scripts/aws/setup_aws_profiles --install` separately\n' >&2
+      return 1
     fi
-  done <<<"${aws_profiles}"
+
+    ;;
+  *)
+    printf -- 'Bailing out...\n' >&2
+    return 2
+    ;;
+  esac
+}
+
+if [[ ! -f "${l_docker_script}" ]]; then
+  install_l_docker || exit $?
 fi
 
-# Iterate over each ECR repo and try to login to ECR
-# When there is not an exact account/region match uses the correct profile
-# configured for same account but for another region.
-for required_repo in "${repository_urls[@]}"; do
-  if [[ "${required_repo}" =~ ${ecr_repo_pattern} ]]; then
-    required_account="${BASH_REMATCH[1]}"
-    required_region="${BASH_REMATCH[2]}"
+if "${l_docker_script}" -l | grep -q "Group ${dev_group_name}"; then
+  "${l_docker_script}" -g "${dev_group_name}"
+else
+  printf -- 'Unexpected setup discovered, using default profile group to login\n'
 
-    profile="$(grep -E "^${required_account}\s${required_region}" "${profile_mapping_file}" | head -n1 | cut -d' ' -f3)"
-
-    while : ""; do
-      if [[ -n "${profile}" ]]; then
-        printf -- 'Logging into %s\n' "${required_repo}"
-
-        aws ecr get-login-password --profile "${profile}" --region "${required_region}" |
-          docker login --username AWS --password-stdin "${required_repo}"
-        break
-      else
-        profile="$(grep -E "^${required_account}\s" "${profile_mapping_file}" | head -n1 | cut -d' ' -f3)"
-
-        if [[ -z "${profile}" ]]; then
-          printf -- 'Could not find profile for '%s' you are going to have to configure one using "aws configure sso"\n' "${required_account}" >&2
-
-          exit 1
-        else
-          break
-        fi
-      fi
-    done
-  fi
-done
+  "${l_docker_script}"
+fi

--- a/src/helpers/config-loader.ts
+++ b/src/helpers/config-loader.ts
@@ -2,9 +2,9 @@ import { existsSync, readFileSync } from "fs";
 import { basename, join } from "path";
 import yaml from "yaml";
 import Config from "../model/Config.js";
+import Constants from "../model/Constants.js";
 
 const fileVarRegExp = /^file:\/\/(.+)$/;
-const DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD = 8;
 
 /**
  * Loads the configuration from the project root. When project does not contain
@@ -19,8 +19,7 @@ export const load: () => Config = () => {
 
     if (!existsSync(confFile)) {
         config = {
-            env: {},
-            authenticatedRepositories: []
+            env: {}
         };
 
     } else {
@@ -30,16 +29,15 @@ export const load: () => Config = () => {
 
         config = {
             env: parseEnv(projectConfiguration.env) || {},
-            authenticatedRepositories: projectConfiguration.authed_repositories || [],
             performEcrLoginHoursThreshold: projectConfiguration.authed_repositories && projectConfiguration.ecr_login_threshold_hours ? projectConfiguration.ecr_login_threshold_hours : undefined,
             versionSpecification: projectConfiguration.version
         };
     }
 
-    if (config.authenticatedRepositories && config.authenticatedRepositories.length > 0 && !config.performEcrLoginHoursThreshold) {
+    if (!config.performEcrLoginHoursThreshold) {
         config = {
             ...config,
-            performEcrLoginHoursThreshold: DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD
+            performEcrLoginHoursThreshold: Constants.DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD
         };
     }
 

--- a/src/hooks/ensure-ecr-logged-in.ts
+++ b/src/hooks/ensure-ecr-logged-in.ts
@@ -16,21 +16,19 @@ export const hook: Hook<"ensure-ecr-logged-in"> = async ({ config, context }) =>
     const projectConfig = loadConfig();
     const executionTime = Date.now();
 
-    if (projectConfig.authenticatedRepositories.length > 0) {
-        const lastRunTimeFile = join(config.dataDir, `${projectConfig.projectName}.prerun.last_run_time`);
+    const lastRunTimeFile = join(config.dataDir, `${projectConfig.projectName}.prerun.last_run_time`);
 
-        const lastRuntimeExists = existsSync(lastRunTimeFile);
+    const lastRuntimeExists = existsSync(lastRunTimeFile);
 
-        const runCheck = "CHS_DEV_FORCE_ECR_CHECK" in process.env || !(lastRuntimeExists && timeWithinThreshold(
-            lastRunTimeFile,
-            executionTime,
+    const runCheck = "CHS_DEV_FORCE_ECR_CHECK" in process.env || !(lastRuntimeExists && timeWithinThreshold(
+        lastRunTimeFile,
+        executionTime,
             projectConfig.performEcrLoginHoursThreshold as number,
             ThresholdUnit.HOURS
-        ));
+    ));
 
-        if (runCheck) {
-            await attemptEcrLogin(config, projectConfig, context, lastRunTimeFile, executionTime);
-        }
+    if (runCheck) {
+        await attemptEcrLogin(config, projectConfig, context, lastRunTimeFile, executionTime);
     }
 };
 
@@ -46,7 +44,7 @@ const attemptEcrLogin = async (
 
     if (runLogin) {
         const dockerEcrLogin = new DockerEcrLogin(
-            config.root, projectConfig, {
+            config.root, {
                 log: console.log
             }
         );

--- a/src/model/Config.ts
+++ b/src/model/Config.ts
@@ -21,12 +21,6 @@ export type Config = {
     readonly env: Record<string, string>;
 
     /**
-     * collection of Docker repositories in use by the project which require
-     * authentication.
-     */
-    readonly authenticatedRepositories: string[];
-
-    /**
      * when supplied defines the threshold for number of hours after which to
      * attempt ecr login
      */

--- a/src/model/Constants.ts
+++ b/src/model/Constants.ts
@@ -11,7 +11,12 @@ export const CONSTANTS = {
     /**
      * Value for a boolean label to be considered true
      */
-    BOOLEAN_LABEL_TRUE_VALUE: "true"
+    BOOLEAN_LABEL_TRUE_VALUE: "true",
+
+    /**
+     * Default value for the number of hours between ecr login checks
+     */
+    DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD: 8
 };
 
 export default CONSTANTS;

--- a/src/run/docker-ecr-login.ts
+++ b/src/run/docker-ecr-login.ts
@@ -8,7 +8,7 @@ import { Logger } from "./logs/logs-handler.js";
 export class DockerEcrLogin {
 
     // eslint-disable-next-line no-useless-constructor
-    constructor (private readonly chsDevInstallDirectory: string, private readonly config: Config, private readonly logger: Logger) { }
+    constructor (private readonly chsDevInstallDirectory: string, private readonly logger: Logger) { }
 
     attemptLoginToDockerEcr (): Promise<void> {
         const awsConfigurationFile = join(process.env.HOME as string, ".aws/config");
@@ -20,10 +20,7 @@ export class DockerEcrLogin {
         return spawn(
             // "/bin/bash",
             join(this.chsDevInstallDirectory, "bin/docker_login.sh"),
-            [
-                "--",
-                ...this.config.authenticatedRepositories
-            ],
+            [],
             {
                 logHandler: new LogEverythingLogHandler(this.logger),
                 spawnOptions: {

--- a/test/commands/sync.spec.ts
+++ b/test/commands/sync.spec.ts
@@ -11,7 +11,6 @@ const chsDevConfig: ChsDevConfig = {
     projectPath: "./docker-chs",
     projectName: "docker-chs",
     env: {},
-    authenticatedRepositories: [],
     versionSpecification: "<=0.1.16"
 };
 

--- a/test/helpers/config-loader.spec.ts
+++ b/test/helpers/config-loader.spec.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import { load } from "../../src/helpers/config-loader";
 import yaml from "yaml";
 import { join } from "path";
+import CONSTANTS from "../../src/model/Constants";
 
 describe("load", () => {
 
@@ -33,7 +34,7 @@ describe("load", () => {
     it("returns empty configuration when no configuration file exists", () => {
         existsSyncMock.mockReturnValue(false);
 
-        expect(load()).toEqual({ projectName: "docker-chs", env: {}, projectPath: pwd, authenticatedRepositories: [] });
+        expect(load()).toEqual({ projectName: "docker-chs", env: {}, projectPath: pwd, performEcrLoginHoursThreshold: CONSTANTS.DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD });
     });
 
     it("returns configuration file with environment when file exists with environment", () => {
@@ -77,9 +78,6 @@ describe("load", () => {
                 ENV_VAR_SIX: "file://~/.file-not-found"
             },
             projectPath: pwd,
-            authenticatedRepositories: [
-                "123456789.dkr.eu-west-2.amazonaws.com"
-            ],
             performEcrLoginHoursThreshold: 8
         });
     });
@@ -103,7 +101,6 @@ describe("load", () => {
             env: {},
             projectPath: pwd,
             projectName: "docker-chs",
-            authenticatedRepositories: ["123456789.dkr.eu-west-2.amazonaws.com"],
             performEcrLoginHoursThreshold: 7
         });
     });
@@ -125,8 +122,8 @@ describe("load", () => {
             env: {},
             projectPath: pwd,
             projectName: "docker-chs",
-            authenticatedRepositories: [],
-            versionSpecification: ">1.0 <2.0"
+            versionSpecification: ">1.0 <2.0",
+            performEcrLoginHoursThreshold: CONSTANTS.DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD
         });
     });
 
@@ -140,6 +137,6 @@ describe("load", () => {
 
         existsSyncMock.mockReturnValue(false);
 
-        expect(load()).toEqual({ projectName: "chs-docker-project", env: {}, projectPath: chsDevProjectPath, authenticatedRepositories: [] });
+        expect(load()).toEqual({ projectName: "chs-docker-project", env: {}, projectPath: chsDevProjectPath, performEcrLoginHoursThreshold: CONSTANTS.DEFAULT_PERFORM_ECR_LOGIN_HOURS_THRESHOLD });
     });
 });

--- a/test/hooks/ensure-ecr-logged-in.spec.ts
+++ b/test/hooks/ensure-ecr-logged-in.spec.ts
@@ -52,16 +52,12 @@ describe("prerun hook", () => {
 
     const environmentConfigWithAuthedRepositories = {
         env: {},
-        authenticatedRepositories: [
-            "123456789.dkr.ecr.eu-west-2.amazonaws.com"
-        ],
         projectPath: "/users/user/docker-chs",
         projectName: "docker-chs",
         performEcrLoginHoursThreshold: 8
     };
     const environmentConfigWithoutAuthedRepositories = {
         env: {},
-        authenticatedRepositories: [],
         projectPath: "/users/user/docker-chs",
         projectName: "docker-chs"
     };
@@ -226,19 +222,6 @@ describe("prerun hook", () => {
                 join(dataDir, "docker-chs.prerun.last_run_time")
             );
 
-        });
-
-        it("does nothing if there are no authed repos", async () => {
-            configLoaderMock.mockReturnValue(
-                environmentConfigWithoutAuthedRepositories
-            );
-
-            // @ts-expect-error
-            await hook({ config: testConfig, context: testContext });
-
-            expect(confirm).not.toHaveBeenCalled();
-            expect(writeFileSyncSpy).not.toHaveBeenCalled();
-            expect(attemptLoginToDockerEcrMock).not.toHaveBeenCalled();
         });
     });
 

--- a/test/run/compose-log-viewer.spec.ts
+++ b/test/run/compose-log-viewer.spec.ts
@@ -31,7 +31,6 @@ describe("ComposeLogViewer", () => {
         composeLogViewer = new ComposeLogViewer({
             env: {},
             projectPath: ".",
-            authenticatedRepositories: [],
             projectName: "docker-chs"
         }, loggerMock);
 

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -24,7 +24,6 @@ describe("DockerCompose", () => {
             ANOTHER_VALUE: "another-value"
         },
         projectPath: "./",
-        authenticatedRepositories: [],
         projectName: "project"
     };
 
@@ -253,8 +252,7 @@ describe("DockerCompose", () => {
             const configMinusEnv = {
                 projectPath: "./",
                 projectName: "project",
-                env: {},
-                authenticatedRepositories: []
+                env: {}
             };
 
             const dockerComposeMinusEnv = new DockerCompose(configMinusEnv, logger);

--- a/test/run/docker-ecr-login.spec.ts
+++ b/test/run/docker-ecr-login.spec.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import { join } from "path";
 import LogEverythingLogHandler from "../../src/run/logs/LogEverythingLogHandler";
 
-describe("DockerLogin", () => {
+describe("DockerEcrLogin", () => {
 
     let DockerEcrLogin;
     let dockerLogin;
@@ -15,12 +15,6 @@ describe("DockerLogin", () => {
             spawn: spawnMock
         };
     });
-
-    const authenticatedRepositories = [
-        "123456789.dkr.ecr.eu-west-1.amazonaws.com",
-        "123456789.dkr.ecr.eu-west-2.amazonaws.com",
-        "223456789.dkr.ecr.eu-west-2.amazonaws.com"
-    ];
 
     const chsDevInstallDir = "/users/user/.chs-dev";
 
@@ -38,11 +32,7 @@ describe("DockerLogin", () => {
         beforeEach(() => {
             jest.resetAllMocks();
 
-            dockerLogin = new DockerEcrLogin(chsDevInstallDir, {
-                env: {},
-                projectPath: ".",
-                authenticatedRepositories
-            }, loggerMock);
+            dockerLogin = new DockerEcrLogin(chsDevInstallDir, loggerMock);
 
         });
 
@@ -77,10 +67,7 @@ describe("DockerLogin", () => {
 
             expect(spawnMock).toHaveBeenCalledWith(
                 join(chsDevInstallDir, "bin/docker_login.sh"),
-                [
-                    "--",
-                    ...authenticatedRepositories
-                ], {
+                [], {
                     logHandler: expect.any(LogEverythingLogHandler),
                     spawnOptions: {
                         shell: "/bin/bash"

--- a/test/run/version-check.spec.ts
+++ b/test/run/version-check.spec.ts
@@ -15,7 +15,6 @@ describe("VersionCheck", () => {
         env: {},
         projectPath: "./docker-project",
         projectName: "docker-project",
-        authenticatedRepositories: [],
         versionSpecification: ">=1.0.0 <2.0.0"
     };
     const loggerMock = {

--- a/test/state/permanent-repositories.spec.ts
+++ b/test/state/permanent-repositories.spec.ts
@@ -86,8 +86,7 @@ const inventoryMock = {
 const config: Config = {
     projectName: "chs-docker",
     projectPath: "./chs-docler",
-    env: {},
-    authenticatedRepositories: []
+    env: {}
 };
 
 const dockerComposeConfigurationIncludingServices = (...services: Service[]) => {


### PR DESCRIPTION
* There was an issue where aws sts get-caller-identity would succeed when user was not logged in therefore could not be used as a way of determining a user was logged into aws, subsequently some work has been done to create a better l_docker which behaves much the same as the former script but should be available as standard on devs machines.
* Remove concept of authenticated repositories since we are not using them to perform docker login
