### PR TITLE
Add further environment variables to skip some of the checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,9 @@ within the current working directory.
   with GitHub's API.
 * `CHS_DEV_NO_PROJECT_VERSION_MISMATCH_WARNING` - when set does not show any
   warnings relating to version not being suitable for project.
+* `CHS_DEV_SKIP_PROJECT_STATE_VALIDATION` - when set will not check that the
+  project is valid before running any commands
+* `CHS_DEV_SKIP_ECR_LOGIN_CHECK` - when set will not attempt to login to ECR
 
 ### Service configuration
 

--- a/src/hooks/ensure-ecr-logged-in.ts
+++ b/src/hooks/ensure-ecr-logged-in.ts
@@ -13,6 +13,10 @@ import Config from "../model/Config.js";
  */
 export const hook: Hook<"ensure-ecr-logged-in"> = async ({ config, context }) => {
 
+    if (typeof process.env.CHS_DEV_SKIP_ECR_LOGIN_CHECK !== "undefined") {
+        return;
+    }
+
     const projectConfig = loadConfig();
     const executionTime = Date.now();
 

--- a/src/hooks/validate-project-state.ts
+++ b/src/hooks/validate-project-state.ts
@@ -15,7 +15,7 @@ import { hookFilter } from "./hook-filter.js";
  */
 export const hook: Hook<"validate-project-state"> = (options) => {
 
-    if (!options.requiredFiles) {
+    if (!options.requiredFiles || typeof process.env.CHS_DEV_SKIP_PROJECT_STATE_VALIDATION !== "undefined") {
         return Promise.resolve();
     }
 

--- a/test/hooks/ensure-ecr-logged-in.spec.ts
+++ b/test/hooks/ensure-ecr-logged-in.spec.ts
@@ -4,25 +4,17 @@ import confirm from "@inquirer/confirm";
 import { hook } from "../../src/hooks/ensure-ecr-logged-in";
 import { join } from "path";
 import { error } from "console";
+import { DockerEcrLogin } from "../../src/run/docker-ecr-login";
+import configLoaderMock from "../../src/helpers/config-loader";
 
 const attemptLoginToDockerEcrMock = jest.fn();
-const configLoaderMock = jest.fn();
+const dockerEcrLoginMock = {
+    attemptLoginToDockerEcr: attemptLoginToDockerEcrMock
+};
 
-jest.mock("../../src/run/docker-ecr-login", () => {
-    return {
-        DockerEcrLogin: function () {
-            return {
-                attemptLoginToDockerEcr: attemptLoginToDockerEcrMock
-            };
-        }
-    };
-});
+jest.mock("../../src/run/docker-ecr-login");
 
-jest.mock("../../src/helpers/config-loader", () => {
-    return () => {
-        return configLoaderMock();
-    };
-});
+jest.mock("../../src/helpers/config-loader");
 
 jest.mock("@inquirer/confirm");
 
@@ -68,6 +60,20 @@ describe("prerun hook", () => {
         Date.now = () => Date.parse(testTimeIsoUtc);
 
         delete process.env.CHS_DEV_FORCE_ECR_CHECK;
+        delete process.env.CHS_DEV_SKIP_ECR_LOGIN_CHECK;
+
+        // @ts-expect-error
+        DockerEcrLogin.mockReturnValue(dockerEcrLoginMock);
+    });
+
+    it("does not run check when CHS_DEV_SKIP_ECR_LOGIN_CHECK is set", async () => {
+        process.env.CHS_DEV_SKIP_ECR_LOGIN_CHECK = "FORCE";
+
+        // @ts-expect-error
+        await hook({ config: testConfig, context: testContext });
+
+        expect(attemptLoginToDockerEcrMock).not.toHaveBeenCalled();
+        expect(writeFileSyncSpy).not.toHaveBeenCalled();
     });
 
     it("always run check when CHS_DEV_FORCE_ECR_CHECK is set", async () => {
@@ -82,6 +88,7 @@ describe("prerun hook", () => {
             Buffer.from(testTimeMinusHours(7), "utf8")
         );
 
+        // @ts-expect-error
         configLoaderMock.mockReturnValue(
             environmentConfigWithAuthedRepositories
         );
@@ -96,11 +103,16 @@ describe("prerun hook", () => {
         beforeEach(() => {
             jest.resetAllMocks();
 
+            // @ts-expect-error
             configLoaderMock.mockReturnValue(
                 environmentConfigWithAuthedRepositories
             );
 
             existsSyncSpy.mockReturnValue(false);
+            delete process.env.CHS_DEV_SKIP_ECR_LOGIN_CHECK;
+
+            // @ts-expect-error
+            DockerEcrLogin.mockReturnValue(dockerEcrLoginMock);
 
         });
 
@@ -230,11 +242,16 @@ describe("prerun hook", () => {
         beforeEach(() => {
             jest.resetAllMocks();
 
+            // @ts-expect-error
             configLoaderMock.mockReturnValue(
                 environmentConfigWithAuthedRepositories
             );
 
             existsSyncSpy.mockReturnValue(true);
+            delete process.env.CHS_DEV_SKIP_ECR_LOGIN_CHECK;
+
+            // @ts-expect-error
+            DockerEcrLogin.mockReturnValue(dockerEcrLoginMock);
 
         });
 

--- a/test/hooks/validate-project-state.spec.ts
+++ b/test/hooks/validate-project-state.spec.ts
@@ -25,6 +25,26 @@ describe("validate-project-state", () => {
 
         // @ts-expect-error
         testConfig = { root: "./", configDir: "./config", cacheDir: "./cache", dataDir: "./data" };
+
+        delete process.env.CHS_DEV_SKIP_PROJECT_STATE_VALIDATION;
+    });
+
+    it("does not do anything when CHS_DEV_SKIP_PROJECT_STATE_VALIDATION env var is set", async () => {
+        process.env.CHS_DEV_SKIP_PROJECT_STATE_VALIDATION = "TRUE";
+
+        const context = {
+            warn: jest.fn(),
+            error: jest.fn()
+        };
+
+        await hook.bind(context as unknown as Hook.Context)({
+            argv: [],
+            config: testConfig,
+            id: "status"
+        });
+
+        expect(existsSyncSpy).not.toHaveBeenCalled();
+        expect(context.error).not.toHaveBeenCalled();
     });
 
     it("checks resolves and does nothing if requiredFiles not supplied", async () => {


### PR DESCRIPTION
* Add `CHS_DEV_SKIP_PROJECT_STATE_VALIDATION` to skip the check that chs-dev is being run from an invalid project
* Add `CHS_DEV_SKIP_ECR_LOGIN_CHECK` to skip the prompt to login to ECR
* Reformat tests for the hook: `ensure-ecr-logged-in` to use automatic rather than manual mocks
