### PR TITLE
Add check for other processes running to init hook

### DIFF
--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -11,6 +11,8 @@ import { Config as ChsDevConfig } from "../model/Config.js";
 import { ComposeLogViewer } from "../run/compose-log-viewer.js";
 import { PermanentRepositories } from "../state/permanent-repositories.js";
 import { Inventory } from "../state/inventory.js";
+import { spawn } from "../helpers/spawn-promise.js";
+import LogEverythingLogHandler from "../run/logs/LogEverythingLogHandler.js";
 
 export default class Up extends Command {
 
@@ -42,7 +44,7 @@ export default class Up extends Command {
 
         this.stateManager = new StateManager(this.chsDevConfig.projectPath);
         this.dependencyCache = new DependencyCache(this.chsDevConfig.projectPath);
-        this.developmentMode = new DevelopmentMode(this.dockerCompose, this.chsDevConfig.projectPath);
+        this.developmentMode = new DevelopmentMode(this.dockerCompose);
         this.composeLogViewer = new ComposeLogViewer(this.chsDevConfig, logger);
         this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
         this.permanentRepositories = new PermanentRepositories(this.chsDevConfig, this.inventory);

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -4,10 +4,24 @@ import { load } from "../helpers/config-loader.js";
 import { isOnVpn } from "../helpers/vpn-check.js";
 import { VersionCheck } from "../run/version-check.js";
 import { hookFilter } from "./hook-filter.js";
+import LogEverythingLogHandler from "../run/logs/LogEverythingLogHandler.js";
+import { spawn } from "../helpers/spawn-promise.js";
+
+const mutuallyExclusiveCommands = [
+    "up",
+    "down"
+];
 
 export const hook: Hook<"init"> = async function (options) {
 
     if (!hookFilter(options.id, options.argv)) {
+        return;
+    }
+
+    if (mutuallyExclusiveCommands.includes(options.id || "") && await anyOtherProcessesRunning()) {
+        options.context.error(
+            "There are other chs-dev processes running. Wait for them to complete or stop them before retrying"
+        );
         return;
     }
 
@@ -35,4 +49,24 @@ export const hook: Hook<"init"> = async function (options) {
 
     await versionCheck.run(options.config.version);
 
+};
+
+const anyOtherProcessesRunning = async () => {
+    try {
+        await spawn(
+            "pgrep",
+            [
+                "-fq",
+                "docker compose .*(watch|up|down)"
+            ],
+            {
+                logHandler: new LogEverythingLogHandler({
+                    log: (_) => {}
+                })
+            }
+        );
+        return true;
+    } catch (exception) {
+        return false;
+    }
 };


### PR DESCRIPTION
* Prevents running `chs-dev up` or `chs-dev down` when there are other process running, this would cause an issue with docker compose state, when running multiple processes at the same time one would be creating containers and other would lose track of them and so will error with errors like: `no container named xyz`
* Remove locking using file from the development mode class. This caused issues and was not foolproof, using this method will prevent multiple processes running when there are multiple docker compose processes running which would interfere with eachother.
* Add check to init when running up or down for other processes
* Reorganise up tests to use automatic not manual mocks
