### PR TITLE
Update behaviour of up to match behaviour of status and service loader

### DIFF
--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -107,26 +107,7 @@ export default class Up extends Command {
     }
 
     private hasServicesInDevelopmentMode (): boolean {
-        if (this.stateManager.snapshot.servicesWithLiveUpdate.length > 0) {
-            return this.hasServiceEnabledInLiveUpdate() ||
-                this.hasServiceFromEnabledModuleInLiveUpdate();
-        }
-
-        return false;
-    }
-
-    private hasServiceFromEnabledModuleInLiveUpdate (): boolean {
-        return this.inventory.services.filter(service => this.stateManager.snapshot.modules.includes(service.module))
-            .some(service => this.stateManager.snapshot.servicesWithLiveUpdate.includes(service.name));
-    }
-
-    private hasServiceEnabledInLiveUpdate (): boolean {
-        return this.stateManager.snapshot.servicesWithLiveUpdate
-            .some(serviceWithLiveUpdate => {
-                const service = this.stateManager.snapshot.services.find(serviceName => serviceName === serviceWithLiveUpdate);
-
-                return typeof service !== "undefined";
-            });
+        return this.stateManager.snapshot.servicesWithLiveUpdate.length > 0;
     }
 
     private async synchroniseServicesInDevelopmentMode (): Promise<any> {

--- a/test/commands/up.spec.ts
+++ b/test/commands/up.spec.ts
@@ -30,18 +30,6 @@ const SERVICES_IN_DEV_MODE = {
     excludedServices: []
 };
 
-const UNRELATED_SERVICE_IN_DEV_MODE = {
-    modules: [
-    ],
-    services: [
-        "service-one"
-    ],
-    servicesWithLiveUpdate: [
-        "service-two"
-    ],
-    excludedServices: []
-};
-
 const MODULE_WITH_SERVICE_IN_DEV_MODE = {
     modules: [
         "module-five"
@@ -252,24 +240,6 @@ describe("Up command", () => {
                     serviceName: SERVICES_IN_DEV_MODE.servicesWithLiveUpdate[0]
                 }
             );
-        });
-
-    });
-
-    describe("services in live update are not enabled", () => {
-
-        beforeEach(() => {
-            jest.resetAllMocks();
-
-            setUpCommand(UNRELATED_SERVICE_IN_DEV_MODE);
-        });
-
-        it("should not run development mode", async () => {
-            await up.run();
-
-            expect(startDevelopmentModeMock).not.toHaveBeenCalled();
-
-            expect(dependencyCacheUpdateMock).not.toHaveBeenCalled();
         });
 
     });


### PR DESCRIPTION
* Currently up will not start development mode unless there are services enabled in development mode which are not transient
