### PR TITLE
Amend secrets assembly function to add to main service when no builder

### DIFF
--- a/src/generator/development/spec-assembly/builder-secrets-spec-assembly-function.ts
+++ b/src/generator/development/spec-assembly/builder-secrets-spec-assembly-function.ts
@@ -13,14 +13,14 @@ const builderSecretsSpecAssemblyFunction: SpecAssemblyFunction = (
         const dockerComposeSpec = getInitialDockerComposeFile(projectPath);
 
         if (typeof dockerComposeSpec.secrets !== "undefined") {
+            const serviceSpec = developmentDockerComposeSpec.services[`${service.name}-builder`] || developmentDockerComposeSpec.services[service.name];
+
             for (const secretName of Object.keys(dockerComposeSpec.secrets)) {
-                if (typeof developmentDockerComposeSpec.services[`${service.name}-builder`].secrets === "undefined") {
-                    developmentDockerComposeSpec.services[`${service.name}-builder`].secrets = [];
+                if (typeof serviceSpec.secrets === "undefined") {
+                    serviceSpec.secrets = [];
                 }
 
-                // When it was previously unset is set above
-                // @ts-expect-error
-                developmentDockerComposeSpec.services[`${service.name}-builder`].secrets.push(
+                serviceSpec.secrets.push(
                     secretName
                 );
             }


### PR DESCRIPTION
* When the secrets required label is set and no builder then applies to main service instead
