### PR TITLE
Fix issue caused by rename of package

### DIFF
--- a/test/run/troubleshoot/artifact/TroubleshootArtifactContext.spec.ts
+++ b/test/run/troubleshoot/artifact/TroubleshootArtifactContext.spec.ts
@@ -1,5 +1,5 @@
 import { expect, jest } from "@jest/globals";
-import { OutputTroubleshootArtifactContext } from "../../../../src/run/troubleshoot/artifact/TroubleshootArtifactContext";
+import { OutputTroubleshootArtifactContext } from "../../../../src/run/troubleshoot/report/TroubleshootArtifactContext";
 import fs from "fs";
 import { join } from "path";
 


### PR DESCRIPTION
* As part of one of the PRs the package `run/troubleshoot/artifact` was renamed `run/troubleshoot/report` there was a missing reference that was not amended
