### PR TITLE
add troubleshoot proxy status feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ $ npm install -g chs-dev
 $ chs-dev COMMAND
 running command...
 $ chs-dev (--version)
-chs-dev/1.3.0 darwin-arm64 node-v20.12.2
+chs-dev/2.0.0 darwin-arm64 node-v20.18.0
 $ chs-dev --help [COMMAND]
 USAGE
   $ chs-dev COMMAND
@@ -193,6 +193,9 @@ USAGE
 * [`chs-dev services enable SERVICES`](#chs-dev-services-enable-services)
 * [`chs-dev status`](#chs-dev-status)
 * [`chs-dev sync`](#chs-dev-sync)
+* [`chs-dev troubleshoot analyse [OUTPUTFILE]`](#chs-dev-troubleshoot-analyse-outputfile)
+* [`chs-dev troubleshoot proxy-status`](#chs-dev-troubleshoot-proxy-status)
+* [`chs-dev troubleshoot report OUTPUTDIRECTORY`](#chs-dev-troubleshoot-report-outputdirectory)
 * [`chs-dev up`](#chs-dev-up)
 
 ## `chs-dev autocomplete [SHELL]`
@@ -604,6 +607,57 @@ DESCRIPTION
   will depend on the number of calls to the GitHub API, the CLI may require the environment
   variable 'GITHUB_PAT' set with a PAT capable of calling GitHub. GitHub rate limiting
   will prevent >60 unauthenticated requests an hour.
+```
+
+## `chs-dev troubleshoot analyse [OUTPUTFILE]`
+
+Provides analyses of the environment to determine root cause of any issues encountered. Providing information to user as to how they can resolve the issues encountered.
+
+```
+USAGE
+  $ chs-dev troubleshoot analyse [OUTPUTFILE] [-q]
+
+ARGUMENTS
+  OUTPUTFILE  Path to output the analysis results (if desired)
+
+FLAGS
+  -q, --quiet  Suppresses log output
+
+DESCRIPTION
+  Provides analyses of the environment to determine root cause of any issues encountered. Providing information to user
+  as to how they can resolve the issues encountered.
+```
+
+## `chs-dev troubleshoot proxy-status`
+
+Checks user's proxy configuration and docker proxy configuration
+
+```
+USAGE
+  $ chs-dev troubleshoot proxy-status
+
+DESCRIPTION
+  Checks user's proxy configuration and docker proxy configuration
+```
+
+## `chs-dev troubleshoot report OUTPUTDIRECTORY`
+
+Produces an artifact containing resources to aid others providing assistance
+
+```
+USAGE
+  $ chs-dev troubleshoot report OUTPUTDIRECTORY [-A] [-a <value>]
+
+ARGUMENTS
+  OUTPUTDIRECTORY  Directory to output the produced report to
+
+FLAGS
+  -A, --skipTroubleshootAnalyses      Whether to skip producing the analyses output if not provided as input (Not
+                                      recommended)
+  -a, --troubleshootAnalyses=<value>  Previously generated analyses of the environment
+
+DESCRIPTION
+  Produces an artifact containing resources to aid others providing assistance
 ```
 
 ## `chs-dev up`

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -18,8 +18,9 @@ import ModulesEnable from "./modules/enable.js";
 import ModulesDisable from "./modules/disable.js";
 import ComposeLogs from "./deprecated/compose-logs.js";
 import ServiceLogs from "./deprecated/service-logs.js";
-import TroubleshootAnalysis from "./troubleshoot/analyse.js";
+import TroubleshootAnalysis from "./troubleshoot/analyse/index.js";
 import TroubleshootReport from "./troubleshoot/report.js";
+import TroubleshootProxyStatus from "./troubleshoot/analyse/proxy-status.js";
 
 export const commands = {
     down: Down,
@@ -43,6 +44,7 @@ export const commands = {
     "modules:disable": ModulesDisable,
     "service-logs": ServiceLogs,
     "troubleshoot:analyse": TroubleshootAnalysis,
+    "troubleshoot:proxy-status": TroubleshootProxyStatus,
     "troubleshoot:report": TroubleshootReport
 };
 

--- a/src/commands/troubleshoot/analyse/index.ts
+++ b/src/commands/troubleshoot/analyse/index.ts
@@ -1,8 +1,8 @@
 import { Args, Command, Config, Flags } from "@oclif/core";
-import { Inventory } from "../../state/inventory.js";
-import TroubleshootAnalyses from "../../run/TroubleshootAnalyses.js";
-import load from "../../helpers/config-loader.js";
-import { StateManager } from "../../state/state-manager.js";
+import { Inventory } from "../../../state/inventory.js";
+import TroubleshootAnalyses from "../../../run/TroubleshootAnalyses.js";
+import load from "../../../helpers/config-loader.js";
+import { StateManager } from "../../../state/state-manager.js";
 
 export default class Analyse extends Command {
 

--- a/src/commands/troubleshoot/analyse/proxy-status.ts
+++ b/src/commands/troubleshoot/analyse/proxy-status.ts
@@ -1,0 +1,104 @@
+import { Command, Config } from "@oclif/core";
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import TroubleShootOutputLogger from "../utils/logger.js";
+
+type DockerSettingsInterface = {
+    OverrideProxyHTTP: string;
+    OverrideProxyHTTPS: string;
+    SettingsVersion:number
+    ProxyHttpMode: string
+    ProxyHTTPMode: string
+}
+
+export default class TroubleshootProxyStatus extends Command {
+
+    static description = "Checks user's proxy configuration " +
+        "and docker proxy configuration  ";
+
+    private readonly outputLogger: TroubleShootOutputLogger;
+
+    constructor (argv: string[], config: Config) {
+        super(argv, config);
+
+        const logger: (msg: string) => void = (msg: string) => this.log(msg);
+        this.outputLogger = new TroubleShootOutputLogger(logger);
+    }
+
+    async run (): Promise<any> {
+        const result = await this.checkCHProxyConfig();
+        if (result === "success") {
+            const dockerProxyResult = await this.checkDockerSettingsConfig();
+            if (dockerProxyResult === "success") {
+                this.outputLogger.logMessage("No issues found on proxy config", "Success");
+                this.exit(0);
+            }
+        } else {
+            this.exit(1);
+        }
+    }
+
+    private checkCHProxyConfig (): Promise<string> {
+        const chProxy = process.env.CH_PROXY_HOST;
+        if (chProxy) {
+            try {
+                const output = execSync(`ping -c3 ${chProxy}`, { encoding: "utf-8" });
+                return Promise.resolve("success");
+            } catch (error) {
+                this.outputLogger.logMessage("HTTPS_PROXY ping unsuccessful", "Error");
+                return Promise.reject(new Error("error"));
+            }
+        } else {
+            this.outputLogger.logMessage("HTTPS_PROXY env missing", "Error");
+            return Promise.reject(new Error("error"));
+        }
+    }
+
+    private checkDockerSettingsConfig (): Promise<string> {
+        const httpProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+        const settingsFilePath = this.getDockerSettingsFilePath;
+
+        try {
+            if (!fs.existsSync(settingsFilePath)) {
+                this.outputLogger.logMessage("Docker settings file not found", "Error");
+                return Promise.reject(new Error("error"));
+
+            }
+
+            const fileContents = fs.readFileSync(settingsFilePath, "utf-8");
+            const settings:DockerSettingsInterface = JSON.parse(fileContents);
+
+            if (
+                !(settings.OverrideProxyHTTP === httpProxy &&
+                settings.OverrideProxyHTTPS === httpProxy &&
+                (settings.ProxyHTTPMode === "manual" || settings.ProxyHttpMode === "manual"))
+            ) {
+                this.outputLogger.logMessage("Docker Proxy Settings invalid", "Error");
+                return Promise.reject(new Error("error"));
+            }
+            return Promise.resolve("success");
+
+        } catch (error) {
+            this.outputLogger.logMessage(`${(error as Error).message}`, "Error");
+            return Promise.reject(new Error("error"));
+
+        }
+    }
+
+    private get getDockerSettingsFilePath (): string {
+        const homeDir = process.env.HOME || os.homedir();
+        switch (process.platform) {
+        case "win32":
+            return path.join(homeDir, "AppData", "Roaming", "Docker", "settings-store.json");
+        case "darwin":
+            return path.join(homeDir, "Library", "Group Containers", "group.com.docker", "settings-store.json");
+        case "linux":
+            return path.join(homeDir, ".docker", "desktop", "settings-store.json");
+        default:
+            throw new Error("Unsupported operating system.");
+        }
+    }
+
+}

--- a/src/commands/troubleshoot/utils/logger.ts
+++ b/src/commands/troubleshoot/utils/logger.ts
@@ -1,0 +1,17 @@
+import { simpleColouriser } from "../../../helpers/colouriser.js";
+
+export default class TroubleshootOutputLogger {
+
+    private readonly logger: (msg: string) => void;
+
+    constructor (logger: (msg: string) => void) {
+        this.logger = logger;
+    }
+
+    logMessage (message: string, stat: "Success" | "Error"): void {
+        stat === "Success"
+            ? this.logger(`${simpleColouriser("SUCCESS!", "bold-green")} ${message}`)
+            : this.logger(`${simpleColouriser("FAILED!", "red")} ${message}`);
+
+    }
+}


### PR DESCRIPTION
[add troubleshoot proxy-status functionality](https://github.com/companieshouse/chs-dev/commit/5c3ca607c38becfd7bea1ca02beadf5edf471528) 
- confirms the proxy configuration are set properly on user's device, by fetching environment proxy variables and test that they are functional.
- checks the docker proxy configurations are correct, by validating docker proxy properties matches the user's device proxy environment variables.
- on successful checks, a message is printed to user
- on failed check(s) a message is printed to user


[rename analyse file and add directory structure](https://github.com/companieshouse/chs-dev/commit/4d86ec03023ba3b0af08c5c833447386f525d0c7) 
- The analyse directory gives structure to the analyse troubleshoot feature.
Other analytical commands should be added into the directory e.g proxy-status; for better modularity and maintainability.
- fix the import paths


[add troubleshoot proxy-status command](https://github.com/companieshouse/chs-dev/commit/8c8cfcec7978450adf2ad1ccf68f1a671db300ac) 
- fix the troubleshoot analyse import path

[add structure to troubleshooting cli messages](https://github.com/companieshouse/chs-dev/commit/6cf8fd155509cde6f2436acb7b22c7eac6b7d35b)


[CC-1642](https://companieshouse.atlassian.net/browse/CC-1642)