### PR TITLE
Add Docker Memory Analysis to Troubleshoot feature

### DIFF
--- a/docs/troubleshooting-remedies/correctly-modify-docker-memory-limit.md
+++ b/docs/troubleshooting-remedies/correctly-modify-docker-memory-limit.md
@@ -1,0 +1,27 @@
+# Correctly Modify Docker Memory Limit guildlines
+
+## Problem Summary
+
+If the `chs-dev troubleshoot analyse` command suggests increasing the allocated memory limit for Docker, follow these steps to adjust the settings effectively.
+
+## Resolution Summary
+
+1. Open the  Docker Desktop application.
+2. Navigate to `Settings` by clicking the gear icon
+3. Select the `Resource` Tab, then click `Advanced`
+4. On Advanced section view, locate the `Memory Limit` settings.
+5. Adjust the memory limit by dragging the slider:
+   - Drag to the right to increase the memory.
+   - Drag to the left to decrease the memory.
+
+## Rationale
+
+Increasing the memory allocation can improve performance, especially when Docker Desktop becomes slow or when running multi-container workloads. Allocating additional resources can help avoid bottlenecks and ensure smooth operation.
+
+## Related issues
+
+<!-- Provide links to any related troubleshooting remedies which may help the user -->
+
+## References/external resources
+
+* [Docker Desktop Settings: Memory Limit](https://docs.docker.com/desktop/settings-and-maintenance/settings/#advanced)

--- a/src/run/troubleshoot/analysis/DockerMemoryAnalysis.ts
+++ b/src/run/troubleshoot/analysis/DockerMemoryAnalysis.ts
@@ -1,0 +1,92 @@
+import { collect, deduplicate } from "../../../helpers/array-reducers.js";
+import {
+    fetchDockerSettings,
+    DockerSettings
+} from "../../../helpers/docker-settings-store.js";
+import Service from "../../../model/Service.js";
+import { Inventory } from "../../../state/inventory.js";
+import { StateManager } from "../../../state/state-manager.js";
+import AnalysisOutcome from "./AnalysisOutcome.js";
+import { AnalysisIssue, TroubleshootAnalysisTaskContext } from "./AnalysisTask.js";
+import os from "os";
+
+const ANALYSIS_HEADLINE = "Check docker's memory allocation size";
+
+const DOCKER_MEMORY_SUGGESTIONS = [
+    "Got to settings on Docker Desktop application",
+    "Select the Resource tab - Advanced",
+    "Add to Memory Limit using the slider"
+];
+
+export default class DockerMemoryAnalysis {
+
+    static readonly ENABLED_SERVICE_COUNT_THRESHOLD:number = 10;
+    static readonly ENABLED_RESOURCE_INTENSIVE_SERVICES :string[] = ["elasticsearch"];
+
+    async analyse ({ inventory, stateManager, config }: TroubleshootAnalysisTaskContext): Promise<AnalysisOutcome> {
+        const issues = this.checkDockerMemorySize(inventory, stateManager);
+
+        return this.createOutcomeFrom(issues ? [issues] : []);
+    }
+
+    private createOutcomeFrom (issues: AnalysisIssue[]): AnalysisOutcome | PromiseLike<AnalysisOutcome> {
+        return issues.length > 0 ? AnalysisOutcome.createWarning(ANALYSIS_HEADLINE, issues) : AnalysisOutcome.createSuccessful(ANALYSIS_HEADLINE);
+    }
+
+    checkDockerMemorySize (inventory: Inventory, stateManager:StateManager): AnalysisIssue | undefined {
+        const result = fetchDockerSettings();
+        const { MemoryMiB } = result as DockerSettings;
+        const issues = result as AnalysisIssue;
+
+        if (!issues.title) {
+            const dockerMemoryInGB = Math.floor(MemoryMiB / 1024);
+            const isBelow12GBMemory = dockerMemoryInGB < 12;
+
+            if (isBelow12GBMemory) {
+                const isAtLeastHalfMemory = this.isHalfAboveDeviceMemory(dockerMemoryInGB);
+
+                if (!isAtLeastHalfMemory) {
+                    return {
+                        title: "Docker memory size is too low",
+                        description: `Docker memory size is ${dockerMemoryInGB}GB. It should be atleast >=12GB or half the device RAM`,
+                        suggestions: DOCKER_MEMORY_SUGGESTIONS,
+                        documentationLinks: []
+                    };
+                }
+
+                const enabledServices = this.getEnabledServices(inventory, stateManager);
+                const enabledServiceCountAboveThreshold = enabledServices.length > DockerMemoryAnalysis.ENABLED_SERVICE_COUNT_THRESHOLD;
+                const resourceIntensiveServiceEnabled = DockerMemoryAnalysis.ENABLED_RESOURCE_INTENSIVE_SERVICES.some((service: string) => enabledServices.includes(service));
+
+                if (enabledServiceCountAboveThreshold || resourceIntensiveServiceEnabled) {
+                    return {
+                        title: "Docker memory size is too low",
+                        description: `Docker memory size should be >=12GB, as resource intensive services may not run properly`,
+                        suggestions: DOCKER_MEMORY_SUGGESTIONS,
+                        documentationLinks: []
+                    };
+                }
+
+            }
+        } else {
+            return issues;
+        }
+
+    }
+
+    private getEnabledServices (inventory: Inventory, stateManager:StateManager): string[] {
+        const state = stateManager.snapshot;
+        return inventory.services
+            .filter(service => state.modules.includes(service.module) || state.services.includes(service.name))
+            .reduce(collect<string, Service>(service => [service.name, ...service.dependsOn || []]), [])
+            .reduce(deduplicate, [])
+            .sort();
+    };
+
+    private isHalfAboveDeviceMemory (dockerMemoryInGB: number):boolean {
+        const totalDeviceMemoryInBytes = os.totalmem();
+        const halfDeviceMemoryInGB = Math.floor((totalDeviceMemoryInBytes / (1024 ** 3)) / 2);
+        return dockerMemoryInGB >= halfDeviceMemoryInGB;
+    }
+
+}

--- a/src/run/troubleshoot/analysis/DockerMemoryAnalysis.ts
+++ b/src/run/troubleshoot/analysis/DockerMemoryAnalysis.ts
@@ -13,10 +13,19 @@ import os from "os";
 const ANALYSIS_HEADLINE = "Check docker's memory allocation size";
 
 const DOCKER_MEMORY_SUGGESTIONS = [
-    "Got to settings on Docker Desktop application",
-    "Select the Resource tab - Advanced",
-    "Add to Memory Limit using the slider"
+    "Adjust Docker Memory Allocation: refer to the documentation for guidance."
 ];
+
+const DOCUMENTATION_LINKS = [
+    "troubleshooting-remedies/correctly-modify-docker-memory-limit.md"
+];
+
+/**
+ * An analysis task that evaluates whether the allocated Docker memory is sufficient to support running services.
+ *
+ * - Verifies if the Docker memory allocation is less than 12GB and if at least 50% of the device's total memory is allocated.
+ * - Checks if the Docker memory allocation is less than 12GB while resource-intensive services are enabled.
+ */
 
 export default class DockerMemoryAnalysis {
 
@@ -50,7 +59,7 @@ export default class DockerMemoryAnalysis {
                         title: "Docker memory size is too low",
                         description: `Docker memory size is ${dockerMemoryInGB}GB. It should be atleast >=12GB or half the device RAM`,
                         suggestions: DOCKER_MEMORY_SUGGESTIONS,
-                        documentationLinks: []
+                        documentationLinks: DOCUMENTATION_LINKS
                     };
                 }
 
@@ -62,8 +71,9 @@ export default class DockerMemoryAnalysis {
                     return {
                         title: "Docker memory size is too low",
                         description: `Docker memory size should be >=12GB, as resource intensive services may not run properly`,
-                        suggestions: DOCKER_MEMORY_SUGGESTIONS,
-                        documentationLinks: []
+                        suggestions: [...DOCKER_MEMORY_SUGGESTIONS, "OR",
+                            "Reduce number of services running"],
+                        documentationLinks: DOCUMENTATION_LINKS
                     };
                 }
 

--- a/src/run/troubleshoot/analysis/analysis-tasks.ts
+++ b/src/run/troubleshoot/analysis/analysis-tasks.ts
@@ -1,10 +1,12 @@
 import AnalysisTask from "./AnalysisTask.js";
+import DockerMemoryAnalysis from "./DockerMemoryAnalysis.js";
 import ProxiesConfiguredCorrectlyAnalysis from "./ProxiesConfiguredCorrectlyAnalysis.js";
 import ServicesInLiveUpdateConfiguredCorrectlyAnalysis from "./ServicesInLiveUpdateConfiguredCorrectlyAnalysis.js";
 
 const analysisTasks: AnalysisTask[] = [
     new ServicesInLiveUpdateConfiguredCorrectlyAnalysis(),
-    new ProxiesConfiguredCorrectlyAnalysis()
+    new ProxiesConfiguredCorrectlyAnalysis(),
+    new DockerMemoryAnalysis()
 ];
 
 export default analysisTasks;

--- a/test/run/troubleshoot/analysis/DockerMemoryAnalysis.spec.ts
+++ b/test/run/troubleshoot/analysis/DockerMemoryAnalysis.spec.ts
@@ -1,0 +1,142 @@
+import { expect, jest } from "@jest/globals";
+import os from "os";
+import AnalysisOutcome from "../../../../src/run/troubleshoot/analysis/AnalysisOutcome";
+import DockerMemoryAnalysis from "../../../../src/run/troubleshoot/analysis/DockerMemoryAnalysis";
+import { TroubleshootAnalysisTaskContext } from "../../../../src/run/troubleshoot/analysis/AnalysisTask";
+import { fetchDockerSettings } from "../../../../src/helpers/docker-settings-store";
+import { modules, services } from "../../../utils/data";
+
+jest.mock("os");
+jest.mock("../../../../src/helpers/docker-settings-store", () => ({
+    fetchDockerSettings: jest.fn()
+}));
+
+const inventoryMock = {
+    services,
+    modules
+};
+
+const stateManagerMock = {
+    snapshot: {
+        modules: [
+            "module-one"
+        ],
+        services: [
+            "service-six",
+            "service-one"
+        ],
+        servicesWithLiveUpdate: [
+            "service-two",
+            "service-ten",
+            "service-nine"
+        ],
+        excludedServices: [
+            "service-four"
+        ]
+    }
+};
+
+describe("DockerMemoryAnalysis", () => {
+    let analysis: DockerMemoryAnalysis;
+    const analysisContext = {
+        inventory: inventoryMock,
+        stateManager: stateManagerMock,
+        config: {
+            projectPath: "/home/user/docker",
+            projectName: "docker",
+            env: {}
+        }
+    } as TroubleshootAnalysisTaskContext;
+
+    beforeEach(async () => {
+        analysis = new DockerMemoryAnalysis();
+        jest.resetAllMocks();
+
+    });
+
+    it("should return a successful outcome if docker memory is >12GB", async () => {
+        const mockDockerSettings = {
+            OverrideProxyHTTP: "http://proxy.example.com",
+            OverrideProxyHTTPS: "http://proxy.example.com",
+            ProxyHttpMode: "manual",
+            ProxyHTTPMode: "manual",
+            MemoryMiB: 16000
+        };
+
+        (fetchDockerSettings as jest.Mock).mockReturnValue(mockDockerSettings);
+
+        const outcome = await analysis.analyse(analysisContext);
+
+        expect(outcome).toBeInstanceOf(AnalysisOutcome);
+        expect(outcome.isSuccess()).toBe(true);
+    });
+
+    it("should return a false outcome if docker memory is <12GB not half the device memory", async () => {
+        const mockDockerSettings = {
+            OverrideProxyHTTP: "http://proxy.example.com",
+            OverrideProxyHTTPS: "http://proxy.example.com",
+            ProxyHttpMode: "manual",
+            ProxyHTTPMode: "manual",
+            MemoryMiB: 10240 // 10GB
+        };
+
+        (fetchDockerSettings as jest.Mock).mockReturnValue(mockDockerSettings);
+
+        // set device memory to 36GB
+        (os.totalmem as jest.Mock).mockReturnValue(38654705664);
+
+        const outcome = await analysis.analyse(analysisContext);
+
+        expect(outcome).toBeInstanceOf(AnalysisOutcome);
+        expect(outcome.isSuccess()).toBe(false);
+    });
+
+    it("should return a truthy outcome if docker memory is <12GB and half the device memory", async () => {
+        const mockDockerSettings = {
+            OverrideProxyHTTP: "http://proxy.example.com",
+            OverrideProxyHTTPS: "http://proxy.example.com",
+            ProxyHttpMode: "manual",
+            ProxyHTTPMode: "manual",
+            MemoryMiB: 8192 // 8GB
+        };
+
+        (fetchDockerSettings as jest.Mock).mockReturnValue(mockDockerSettings);
+
+        // set device memory to 16GB
+        (os.totalmem as jest.Mock).mockReturnValue(17179869184);
+
+        const outcome = await analysis.analyse(analysisContext);
+
+        expect(outcome).toBeInstanceOf(AnalysisOutcome);
+        expect(outcome.isSuccess()).toBe(true);
+    });
+
+    it("should return an issue if docker memory is less than 12GB and half the device memory, an intensive service is enabled or the number of enabled services threshold is exceeded", async () => {
+        const mockDockerSettings = {
+            OverrideProxyHTTP: "http://proxy.example.com",
+            OverrideProxyHTTPS: "http://proxy.example.com",
+            ProxyHttpMode: "manual",
+            ProxyHTTPMode: "manual",
+            MemoryMiB: 8192 // 8GB
+        };
+
+        (fetchDockerSettings as jest.Mock).mockReturnValue(mockDockerSettings);
+
+        // set device memory to 16GB
+        (os.totalmem as jest.Mock).mockReturnValue(17179869184);
+
+        Object.defineProperty(DockerMemoryAnalysis, "ENABLED_SERVICE_COUNT_THRESHOLD", {
+            value: 5,
+            writable: false
+        });
+        Object.defineProperty(DockerMemoryAnalysis, "ENABLED_RESOURCE_INTENSIVE_SERVICES", {
+            value: ["redis", "service-one"],
+            writable: false
+        });
+
+        const outcome = await analysis.analyse(analysisContext);
+        expect(outcome).toBeInstanceOf(AnalysisOutcome);
+        expect(outcome.isSuccess()).toBe(false);
+    });
+
+});


### PR DESCRIPTION
- returns a warning if the docker settings-store.js file is not found
- returns a warning if docker memory size is less than 12GB but not half the device RAM
- returns a warning if docker memory size is less than 12GB but half the device RAM, and more than 10 services are enabled or resource intensive services(elasticsearch) are enabled
- Add test suites
- Add docker memory to the analysis task steps.