### PR TITLE
Add ECRLogin Analysis to Troubleshoot feature 

### DIFF
--- a/src/commands/troubleshoot/analyse.ts
+++ b/src/commands/troubleshoot/analyse.ts
@@ -30,7 +30,7 @@ export default class Analyse extends Command {
 
     constructor (argv: string[], config: Config) {
         super(argv, config);
-        const chsDevConfig = load();
+        const chsDevConfig = load(config);
 
         const inventory = new Inventory(chsDevConfig.projectPath, config.cacheDir);
         const stateManager = new StateManager(chsDevConfig.projectPath);

--- a/src/helpers/config-loader.ts
+++ b/src/helpers/config-loader.ts
@@ -3,6 +3,7 @@ import { basename, join } from "path";
 import yaml from "yaml";
 import Config from "../model/Config.js";
 import Constants from "../model/Constants.js";
+import { Config as CMConfig } from "@oclif/core";
 
 const fileVarRegExp = /^file:\/\/(.+)$/;
 
@@ -11,7 +12,7 @@ const fileVarRegExp = /^file:\/\/(.+)$/;
  * configuration then returns an empty configuration object.
  * @returns Project Config
  */
-export const load: () => Config = () => {
+export const load: (commandConfig?: CMConfig) => Config = (commandConfig) => {
     const projectPath = process.env.CHS_DEV_PROJECT || process.cwd();
     const confFile = join(projectPath, "chs-dev/config.yaml");
 
@@ -41,10 +42,15 @@ export const load: () => Config = () => {
         };
     }
 
+    const chsDevConfig = commandConfig
+        ? { chsDevPath: commandConfig.root, chsDevDataDir: commandConfig.dataDir }
+        : {};
+
     return {
         ...config,
         projectPath,
-        projectName: basename(projectPath)
+        projectName: basename(projectPath),
+        ...chsDevConfig
     } as Config;
 };
 

--- a/src/model/Config.ts
+++ b/src/model/Config.ts
@@ -15,6 +15,16 @@ export type Config = {
     readonly projectPath: string;
 
     /**
+     * path to the chs-dev local repository
+     */
+    readonly chsDevPath: string;
+
+    /**
+     * path to the chs-dev data
+     */
+    readonly chsDevDataDir: string;
+
+    /**
      * additional environment variables for running the environment. Values can
      * contain 'file://' prefixes will try to read file in and set as value in
      * its place.

--- a/src/model/Config.ts
+++ b/src/model/Config.ts
@@ -17,12 +17,12 @@ export type Config = {
     /**
      * path to the chs-dev local repository
      */
-    readonly chsDevPath: string;
+    readonly chsDevPath?: string;
 
     /**
      * path to the chs-dev data
      */
-    readonly chsDevDataDir: string;
+    readonly chsDevDataDir?: string;
 
     /**
      * additional environment variables for running the environment. Values can

--- a/src/run/troubleshoot/analysis/AbstractBaseAnalysis.ts
+++ b/src/run/troubleshoot/analysis/AbstractBaseAnalysis.ts
@@ -1,0 +1,35 @@
+import AnalysisOutcome from "./AnalysisOutcome.js";
+import { AnalysisIssue, AnalysisFailureLevel } from "./AnalysisTask.js";
+
+export default abstract class BaseAnalysis {
+    /**
+     * Creates an AnalysisOutcome based on the provided issues and level.
+     *
+     * @param headline - The headline for the analysis outcome.
+     * @param issues - The issues found during the analysis. Can be a single issue, multiple issues, or undefined.
+     * @param level - The severity level for the outcome: "Warn", "Fail", or "Info".
+     * @returns An AnalysisOutcome instance based on the provided parameters or a successful outcome.
+     */
+    protected createOutcomeFrom (
+        headline: string,
+        issues: AnalysisIssue[] | AnalysisIssue | undefined,
+        level?: "Warn" | "Fail" | "Info"
+    ): AnalysisOutcome {
+        const normalizedIssues = issues ? (Array.isArray(issues) ? issues : [issues]) : [];
+
+        if (normalizedIssues.length > 0) {
+            const failureLevel =
+                level === "Info"
+                    ? AnalysisFailureLevel.INFO
+                    : level === "Fail"
+                        ? AnalysisFailureLevel.FAIL
+                        : AnalysisFailureLevel.WARN;
+
+            return AnalysisOutcome.createOutcome(headline, normalizedIssues, failureLevel);
+        }
+
+        // No issues, return a successful outcome
+        return new AnalysisOutcome(headline, []);
+    }
+
+}

--- a/src/run/troubleshoot/analysis/AnalysisOutcome.ts
+++ b/src/run/troubleshoot/analysis/AnalysisOutcome.ts
@@ -19,25 +19,7 @@ export default class AnalysisOutcome {
         return this.issues.length === 0;
     }
 
-    static createFailed (headline: string, issues: AnalysisIssue[]) {
-        return new AnalysisOutcome(
-            headline, issues, AnalysisFailureLevel.FAIL
-        );
-    }
-
-    static createWarning (headline: string, issues: AnalysisIssue[]) {
-        return new AnalysisOutcome(
-            headline, issues, AnalysisFailureLevel.WARN
-        );
-    }
-
-    static createInformational (headline: string, issues: AnalysisIssue[]) {
-        return new AnalysisOutcome(
-            headline, issues, AnalysisFailureLevel.INFO
-        );
-    }
-
-    static createSuccessful (headline: string) {
-        return new AnalysisOutcome(headline, []);
+    static createOutcome (headline: string, issues: AnalysisIssue[], level: AnalysisFailureLevel) {
+        return new AnalysisOutcome(headline, issues, level);
     }
 }

--- a/src/run/troubleshoot/analysis/DockerMemoryAnalysis.ts
+++ b/src/run/troubleshoot/analysis/DockerMemoryAnalysis.ts
@@ -6,6 +6,7 @@ import {
 import Service from "../../../model/Service.js";
 import { Inventory } from "../../../state/inventory.js";
 import { StateManager } from "../../../state/state-manager.js";
+import BaseAnalysis from "./AbstractBaseAnalysis.js";
 import AnalysisOutcome from "./AnalysisOutcome.js";
 import { AnalysisIssue, TroubleshootAnalysisTaskContext } from "./AnalysisTask.js";
 import os from "os";
@@ -27,19 +28,14 @@ const DOCUMENTATION_LINKS = [
  * - Checks if the Docker memory allocation is less than 12GB while resource-intensive services are enabled.
  */
 
-export default class DockerMemoryAnalysis {
+export default class DockerMemoryAnalysis extends BaseAnalysis {
 
     static readonly ENABLED_SERVICE_COUNT_THRESHOLD:number = 10;
-    static readonly ENABLED_RESOURCE_INTENSIVE_SERVICES :string[] = ["elasticsearch"];
+    static readonly ENABLED_RESOURCE_INTENSIVE_SERVICES: string[] = ["elasticsearch"];
 
     async analyse ({ inventory, stateManager, config }: TroubleshootAnalysisTaskContext): Promise<AnalysisOutcome> {
         const issues = this.checkDockerMemorySize(inventory, stateManager);
-
-        return this.createOutcomeFrom(issues ? [issues] : []);
-    }
-
-    private createOutcomeFrom (issues: AnalysisIssue[]): AnalysisOutcome | PromiseLike<AnalysisOutcome> {
-        return issues.length > 0 ? AnalysisOutcome.createWarning(ANALYSIS_HEADLINE, issues) : AnalysisOutcome.createSuccessful(ANALYSIS_HEADLINE);
+        return this.createOutcomeFrom(ANALYSIS_HEADLINE, issues, "Warn");
     }
 
     checkDockerMemorySize (inventory: Inventory, stateManager:StateManager): AnalysisIssue | undefined {

--- a/src/run/troubleshoot/analysis/ECRLoginAnalysis.ts
+++ b/src/run/troubleshoot/analysis/ECRLoginAnalysis.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { ThresholdUnit, timeWithinThreshold } from "../../../helpers/time-within-threshold.js";
+import Config from "../../../model/Config.js";
+import BaseAnalysis from "./AbstractBaseAnalysis.js";
+import AnalysisOutcome from "./AnalysisOutcome.js";
+import { AnalysisIssue, TroubleshootAnalysisTaskContext } from "./AnalysisTask.js";
+
+const ANALYSIS_HEADLINE = "Checks the ECR login status of User";
+
+const ECR_LOGIN_SUGGESTIONS = [];
+
+const DOCUMENTATION_LINKS = [];
+
+/**
+ * An analysis task that evaluates whether the user is logged into ECR.
+ * It checks the user's ECR login status using the last runtime file and a threshold configuration for the verification of a current or previous login.
+ */
+
+export default class ECRLoginAnalysis extends BaseAnalysis {
+
+    async analyse ({ inventory, stateManager, config }: TroubleshootAnalysisTaskContext): Promise<AnalysisOutcome> {
+        const issues = await this.checkUserECRLoginStatus(config);
+
+        return this.createOutcomeFrom(ANALYSIS_HEADLINE, issues, "Fail");
+    }
+
+    async checkUserECRLoginStatus (config: Config): Promise<AnalysisIssue | undefined> {
+        const projectConfig = config;
+        const executionTime = Date.now();
+
+        const lastRunTimeFile = join(config.chsDevDataDir, `${projectConfig.projectName}.prerun.last_run_time`);
+
+        const lastRuntimeExists = existsSync(lastRunTimeFile);
+
+        const isUserEcrLoginValid = lastRuntimeExists && timeWithinThreshold(
+            lastRunTimeFile,
+            executionTime,
+                    projectConfig.performEcrLoginHoursThreshold as number,
+                    ThresholdUnit.HOURS
+        );
+
+        if (!isUserEcrLoginValid) {
+            return {
+                title: "User Not Logged into ECR",
+                description: "The login logs indicate that the user is either not logged in or the login session has expired.",
+                suggestions: ECR_LOGIN_SUGGESTIONS,
+                documentationLinks: DOCUMENTATION_LINKS
+            };
+
+        }
+
+    }
+
+}

--- a/src/run/troubleshoot/analysis/ECRLoginAnalysis.ts
+++ b/src/run/troubleshoot/analysis/ECRLoginAnalysis.ts
@@ -37,8 +37,8 @@ export default class ECRLoginAnalysis extends BaseAnalysis {
             const isUserEcrLoginValid = lastRuntimeExists && timeWithinThreshold(
                 lastRunTimeFile,
                 executionTime,
-                        performEcrLoginHoursThreshold as number,
-                        ThresholdUnit.HOURS
+                performEcrLoginHoursThreshold as number,
+                ThresholdUnit.HOURS
             );
 
             if (!isUserEcrLoginValid) {

--- a/src/run/troubleshoot/analysis/ProxiesConfiguredCorrectlyAnalysis.ts
+++ b/src/run/troubleshoot/analysis/ProxiesConfiguredCorrectlyAnalysis.ts
@@ -1,5 +1,6 @@
 import { DockerSettings, fetchDockerSettings } from "../../../helpers/docker-settings-store.js";
 import { isOnVpn, isWebProxyHostSet } from "../../../helpers/vpn-check.js";
+import BaseAnalysis from "./AbstractBaseAnalysis.js";
 import AnalysisOutcome from "./AnalysisOutcome.js";
 import { AnalysisIssue, TroubleshootAnalysisTaskContext } from "./AnalysisTask.js";
 
@@ -22,7 +23,7 @@ const DOCKER_PROXY_CONFIGURATION_SUGGESTIONS = [
  * An analysis task which checks whether the proxy configuration for the user device are configured correctly.
  */
 
-export default class ProxiesConfiguredCorrectlyAnalysis {
+export default class ProxiesConfiguredCorrectlyAnalysis extends BaseAnalysis {
 
     async analyse (context: TroubleshootAnalysisTaskContext): Promise<AnalysisOutcome> {
 
@@ -31,13 +32,7 @@ export default class ProxiesConfiguredCorrectlyAnalysis {
 
         const issues: AnalysisIssue[] = [vpnIssues, dockerIssues].filter((issue): issue is AnalysisIssue => issue !== undefined);
 
-        return this.createOutcomeFrom(issues);
-    }
-
-    private createOutcomeFrom (issues: AnalysisIssue[]): AnalysisOutcome | PromiseLike<AnalysisOutcome> {
-        return issues.length > 0
-            ? AnalysisOutcome.createFailed(ANALYSIS_HEADLINE, issues)
-            : AnalysisOutcome.createSuccessful(ANALYSIS_HEADLINE);
+        return this.createOutcomeFrom(ANALYSIS_HEADLINE, issues, "Fail");
     }
 
     private checkCHProxyConfig (): AnalysisIssue | undefined {

--- a/src/run/troubleshoot/analysis/ServicesInLiveUpdateConfiguredCorrectlyAnalysis.ts
+++ b/src/run/troubleshoot/analysis/ServicesInLiveUpdateConfiguredCorrectlyAnalysis.ts
@@ -5,6 +5,7 @@ import { existsSync } from "fs";
 import Service from "../../../model/Service.js";
 import Config from "../../../model/Config.js";
 import { getBuilders } from "../../../state/builders.js";
+import BaseAnalysis from "./AbstractBaseAnalysis.js";
 
 const ANALYSIS_HEADLINE = "Check for services in development mode correctly configured";
 const REPOSITORY_BUILDER_MISSING_DOCKERFILE_TITLE = "Missing Dockerfile for service in Development mode without builder label";
@@ -25,7 +26,7 @@ const DOCUMENTATION_LINKS = [
  * mode are correctly configured with a Dockerfile - either from the builder
  * label or whether the repository itself has a Dockerfile within it.
  */
-export default class ServicesInLiveUpdateConfiguredCorrectlyAnalysis {
+export default class ServicesInLiveUpdateConfiguredCorrectlyAnalysisextends extends BaseAnalysis {
 
     async analyse ({ inventory, stateManager, config }: TroubleshootAnalysisTaskContext): Promise<AnalysisOutcome> {
         const servicesInLiveUpdate = inventory.services.filter(
@@ -36,7 +37,7 @@ export default class ServicesInLiveUpdateConfiguredCorrectlyAnalysis {
             .map(service => this.analyseService(service, config))
             .filter(issueOrUndefined => typeof issueOrUndefined !== "undefined") as AnalysisIssue[];
 
-        return this.createOutcomeFrom(issues);
+        return this.createOutcomeFrom(ANALYSIS_HEADLINE, issues, "Warn");
     }
 
     private analyseService (service: Service, config: Config) {
@@ -62,12 +63,6 @@ export default class ServicesInLiveUpdateConfiguredCorrectlyAnalysis {
             }
         }
         return issue;
-    }
-
-    private createOutcomeFrom (issues: AnalysisIssue[]): AnalysisOutcome | PromiseLike<AnalysisOutcome> {
-        return issues.length > 0
-            ? AnalysisOutcome.createWarning(ANALYSIS_HEADLINE, issues)
-            : AnalysisOutcome.createSuccessful(ANALYSIS_HEADLINE);
     }
 
     private constructSuggestionsForIncorrectBuilder (config: Config): string[] {

--- a/src/run/troubleshoot/analysis/analysis-tasks.ts
+++ b/src/run/troubleshoot/analysis/analysis-tasks.ts
@@ -1,12 +1,14 @@
 import AnalysisTask from "./AnalysisTask.js";
 import DockerMemoryAnalysis from "./DockerMemoryAnalysis.js";
+import ECRLoginAnalysis from "./ECRLoginAnalysis.js";
 import ProxiesConfiguredCorrectlyAnalysis from "./ProxiesConfiguredCorrectlyAnalysis.js";
 import ServicesInLiveUpdateConfiguredCorrectlyAnalysis from "./ServicesInLiveUpdateConfiguredCorrectlyAnalysis.js";
 
 const analysisTasks: AnalysisTask[] = [
     new ServicesInLiveUpdateConfiguredCorrectlyAnalysis(),
     new ProxiesConfiguredCorrectlyAnalysis(),
-    new DockerMemoryAnalysis()
+    new DockerMemoryAnalysis(),
+    new ECRLoginAnalysis()
 ];
 
 export default analysisTasks;

--- a/test/run/troubleshoot/analysis/ECRLoginAnalysis.spec.ts
+++ b/test/run/troubleshoot/analysis/ECRLoginAnalysis.spec.ts
@@ -1,0 +1,111 @@
+import { expect, jest } from "@jest/globals";
+import AnalysisOutcome from "../../../../src/run/troubleshoot/analysis/AnalysisOutcome";
+import { TroubleshootAnalysisTaskContext } from "../../../../src/run/troubleshoot/analysis/AnalysisTask";
+import ECRLoginAnalysis from "../../../../src/run/troubleshoot/analysis/ECRLoginAnalysis";
+import * as fs from "fs";
+import { timeWithinThreshold, ThresholdUnit } from "../../../../src/helpers/time-within-threshold";
+
+jest.mock("fs");
+
+jest.mock("../../../../src/helpers/time-within-threshold", () => ({
+    timeWithinThreshold: jest.fn(),
+    ThresholdUnit: {
+        MINUTES: 1000 * 60,
+        HOURS: 1000 * 60 * 60,
+        DAYS: 1000 * 60 * 60 * 24
+    }
+}));
+
+describe("ECRLoginAnalysis", () => {
+    let analysis: ECRLoginAnalysis;
+
+    beforeEach(async () => {
+        analysis = new ECRLoginAnalysis();
+        jest.resetAllMocks();
+
+    });
+
+    it("should return an issue if the DataDir property is not set", async () => {
+
+        const analysisContext = {
+            inventory: {},
+            stateManager: {},
+            config: {
+                projectPath: "/home/user/docker",
+                projectName: "docker",
+                performEcrLoginHoursThreshold: 2,
+                env: {}
+            }
+        } as TroubleshootAnalysisTaskContext;
+
+        const outcome = await analysis.analyse(analysisContext);
+
+        expect(outcome).toBeInstanceOf(AnalysisOutcome);
+        expect(outcome.isSuccess()).toBe(false);
+        expect(outcome.issues).toEqual([
+            {
+                title: "ECR Login Status Check Failed",
+                description: "Unable to perform check. DataDir path is missing from configuration.",
+                suggestions: [],
+                documentationLinks: []
+            }
+        ]);
+    });
+
+    it("should return an issue if the lastRunTimeFile doesnt exist or threshold has been exceeded  ", async () => {
+
+        const analysisContext = {
+            inventory: {},
+            stateManager: {},
+            config: {
+                projectPath: "/home/user/docker",
+                projectName: "docker",
+                performEcrLoginHoursThreshold: 7,
+                chsDevDataDir: "/mock/path/data.dir",
+                env: {}
+            }
+        } as TroubleshootAnalysisTaskContext;
+
+        (fs.existsSync as jest.Mock).mockReturnValue(false); // lastRunTimeFile doesnt exist
+
+        (timeWithinThreshold as jest.Mock).mockReturnValue(false); // threshold is exceeded
+
+        const outcome = await analysis.analyse(analysisContext);
+
+        expect(outcome).toBeInstanceOf(AnalysisOutcome);
+        expect(outcome.isSuccess()).toBe(false);
+        expect(outcome.issues).toEqual([
+            {
+                title: "User Not Logged into ECR",
+                description: "The login logs indicate that the user is either not logged in or the login session has expired.",
+                suggestions: [],
+                documentationLinks: []
+            }
+        ]);
+    });
+
+    it("should not return an issue if the lastRunTimeFile exist and threshold is not exceeded  ", async () => {
+
+        const analysisContext = {
+            inventory: {},
+            stateManager: {},
+            config: {
+                projectPath: "/home/user/docker",
+                projectName: "docker",
+                performEcrLoginHoursThreshold: 7,
+                chsDevDataDir: "/mock/path/data.dir",
+                env: {}
+            }
+        } as TroubleshootAnalysisTaskContext;
+
+        (fs.existsSync as jest.Mock).mockReturnValue(true); // lastRunTimeFile exist
+
+        (timeWithinThreshold as jest.Mock).mockReturnValue(true); // threshold is not exceeded
+
+        const outcome = await analysis.analyse(analysisContext);
+
+        expect(outcome).toBeInstanceOf(AnalysisOutcome);
+        expect(outcome.isSuccess()).toBe(true);
+    });
+
+});


### PR DESCRIPTION
[Add ECRLoginAnalysis Check](https://github.com/companieshouse/chs-dev/commit/ab7a67214966dc3737f30e8c56119ab928a7f0c5) 

- logic is to evaluates the user's ECR login status using the last runtime file and the ecr threshold configuration
for the verification of a current or previous login.
- add the check to the list of task in the analysis-task queue


[Add the oclif command configurations into Config](https://github.com/companieshouse/chs-dev/commit/107dc596da231c59b5fbb4bd9325aec4365f3799) 

- The ecr login check depends on certain configuration path to be available which is missing in the Config model
To fix this:-
1. refactor the config-loader helper function to accept the command config object as an optional parameter
2. modify the config model by adding new properties from the command config object
3. modify the `load()` call in the `analyse` class to accept the command config object as an argument.


[Set the command config props as optional](https://github.com/companieshouse/chs-dev/commit/a9a45cd6ae34f3a57b7af4a0dbffcfaef8cf4c2f) 

- set the property objects as optional.
- refactor the checkUserECRLoginStatus function to return an issue if the need property is not provided

[add unit test for ECRLogin](https://github.com/companieshouse/chs-dev/commit/a4ca4e0d50dca2ad147d0291bcfdf4c99016cc5e)
