### PR TITLE
Task/sort development services output

### DIFF
--- a/src/commands/development/services.ts
+++ b/src/commands/development/services.ts
@@ -33,7 +33,10 @@ export default class Services extends Command {
     async run (): Promise<any> {
         const { flags } = await this.parse(Services);
 
-        const availableServices = this.inventory.services.filter(item => item.repository !== null && item.repository !== undefined);
+        const availableServices = this.inventory.services
+            .filter(item => item.repository !== null && item.repository !== undefined)
+            .sort((a, b) => a.name.localeCompare(b.name));
+
         if (flags.json) {
             this.logJson({
                 services: [


### PR DESCRIPTION
- Arrange the `chs-dev development services` command output in alphabetical order.