### PR TITLE
CC-2017:Fix AWS expired credentials error when fetching refreshed credentials.

### DIFF
--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -201,21 +201,23 @@ export class DockerCompose {
      * @throws {Error} If the AWS CLI command fails or credentials cannot be retrieved.
     */
     private get getAwsCredentials (): Record<string, string> {
+        if (AWS_PROFILE === "undefined") {
+            throw new Error(`Fetch AWS credentials failed: Invalid profile '${AWS_PROFILE}' detected. Run: 'chs-dev troubleshoot analyse' command to troubleshoot.`);
+        }
+
         try {
             const output = execSync(`aws configure export-credentials --profile ${AWS_PROFILE} --format env`, { encoding: "utf-8" });
 
-            // parse output into an object
-            const awsCredentials = output
+            return output
                 .split("\n")
                 .filter(line => line.startsWith("export "))
-                .map(line => line.replace("export ", "").split("="))
-                .reduce((acc, [key, value]) => {
+                .reduce((acc, line) => {
+                    const [key, value] = line.replace("export ", "").split("=");
                     acc[key] = value;
                     return acc;
-                }, {});
-            return awsCredentials;
-        } catch (error:any) {
-            throw new Error(`Fetch AWS credentials failed: ${error}. Run: 'chs-dev troubleshoot analyse' command to troubleshoot.`);
+                }, {} as Record<string, string>);
+        } catch (error: any) {
+            throw new Error(`Fetch AWS credentials failed: ${error.message || error}. Run: 'chs-dev troubleshoot analyse' command to troubleshoot.`);
         }
     }
 

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -22,7 +22,7 @@ const CONTAINER_STOPPED_STATUS_PATTERN =
 const CONTAINER_STARTED_HEALTHY_STATUS_PATTERN =
     /(?:Container\s)?([\dA-Za-z-]+)\s*(Started|Healthy|Stopped|Pulling|Pulled)/;
 
-const AWS_PROFILE = process.env.AWS_PROFILE || "undefined";
+const AWS_PROFILE = process.env.AWS_PROFILE;
 
 type LogsArgs = {
     serviceNames: string[] | undefined,
@@ -201,8 +201,8 @@ export class DockerCompose {
      * @throws {Error} If the AWS CLI command fails or credentials cannot be retrieved.
     */
     private get getAwsCredentials (): Record<string, string> {
-        if (AWS_PROFILE === "undefined") {
-            throw new Error(`Fetch AWS credentials failed: Invalid profile '${AWS_PROFILE}' detected. Run: 'chs-dev troubleshoot analyse' command to troubleshoot.`);
+        if (!AWS_PROFILE || AWS_PROFILE === "undefined") {
+            throw new Error("Fetch AWS credentials failed: invalid profile detected. Run:'chs-dev troubleshoot analyse' command to troubleshoot.");
         }
 
         try {

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -23,6 +23,7 @@ const CONTAINER_STARTED_HEALTHY_STATUS_PATTERN =
     /(?:Container\s)?([\dA-Za-z-]+)\s*(Started|Healthy|Stopped|Pulling|Pulled)/;
 
 const AWS_PROFILE = process.env.AWS_PROFILE;
+const INVALID_PROFILE_NAMES = ["undefined"];
 
 type LogsArgs = {
     serviceNames: string[] | undefined,
@@ -234,7 +235,7 @@ export class DockerCompose {
      * @throws {Error} If the AWS CLI command fails or credentials cannot be retrieved.
     */
     private get getAwsCredentials (): Record<string, string> {
-        if (!AWS_PROFILE || AWS_PROFILE === "undefined") {
+        if (!AWS_PROFILE || INVALID_PROFILE_NAMES.includes(AWS_PROFILE)) {
             throw new Error("Fetch AWS credentials failed: invalid profile detected. Run:'chs-dev troubleshoot analyse' command to troubleshoot.");
         }
 

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -22,6 +22,8 @@ const CONTAINER_STOPPED_STATUS_PATTERN =
 const CONTAINER_STARTED_HEALTHY_STATUS_PATTERN =
     /(?:Container\s)?([\dA-Za-z-]+)\s*(Started|Healthy|Stopped|Pulling|Pulled)/;
 
+const AWS_PROFILE = process.env.AWS_PROFILE || "undefined";
+
 type LogsArgs = {
     serviceNames: string[] | undefined,
     tail: string | undefined,
@@ -200,7 +202,7 @@ export class DockerCompose {
     */
     private get getAwsCredentials (): Record<string, string> {
         try {
-            const output = execSync("aws configure export-credentials --format env", { encoding: "utf-8" });
+            const output = execSync(`aws configure export-credentials --profile ${AWS_PROFILE} --format env`, { encoding: "utf-8" });
 
             // parse output into an object
             const awsCredentials = output

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -201,11 +201,10 @@ export class DockerCompose {
      * @throws {Error} If the AWS CLI command fails or credentials cannot be retrieved.
     */
     private get getAwsCredentials (): Record<string, string> {
-        if (AWS_PROFILE === "undefined") {
-            throw new Error(`Fetch AWS credentials failed: Invalid profile '${AWS_PROFILE}' detected. Run: 'chs-dev troubleshoot analyse' command to troubleshoot.`);
-        }
-
         try {
+            if (AWS_PROFILE === "undefined") {
+                throw new Error(`Fetch AWS credentials failed: Invalid profile '${AWS_PROFILE}' detected. Run: 'chs-dev troubleshoot analyse' command to troubleshoot.`);
+            }
             const output = execSync(`aws configure export-credentials --profile ${AWS_PROFILE} --format env`, { encoding: "utf-8" });
 
             return output

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -201,10 +201,11 @@ export class DockerCompose {
      * @throws {Error} If the AWS CLI command fails or credentials cannot be retrieved.
     */
     private get getAwsCredentials (): Record<string, string> {
+        if (AWS_PROFILE === "undefined") {
+            throw new Error(`Fetch AWS credentials failed: Invalid profile '${AWS_PROFILE}' detected. Run: 'chs-dev troubleshoot analyse' command to troubleshoot.`);
+        }
+
         try {
-            if (AWS_PROFILE === "undefined") {
-                throw new Error(`Fetch AWS credentials failed: Invalid profile '${AWS_PROFILE}' detected. Run: 'chs-dev troubleshoot analyse' command to troubleshoot.`);
-            }
             const output = execSync(`aws configure export-credentials --profile ${AWS_PROFILE} --format env`, { encoding: "utf-8" });
 
             return output

--- a/src/run/troubleshoot/analysis/AwsEnvironmentVariableAnalysis.ts
+++ b/src/run/troubleshoot/analysis/AwsEnvironmentVariableAnalysis.ts
@@ -32,7 +32,7 @@ export default class AwsEnvironmentVariableAnalysis extends BaseAnalysis {
      */
     private checkAwsProfileEnvVariable (): AnalysisIssue | undefined {
         const AWS_PROFILE = process.env.AWS_PROFILE;
-        const profiles = this.fetchAwsProfiles();
+        const profiles = this.fetchAwsProfiles().filter(profile => profile !== "undefined");
 
         if (!AWS_PROFILE || !profiles.includes(AWS_PROFILE)) {
             return this.createIssue(

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -76,7 +76,7 @@ describe("DockerCompose", () => {
         AWS_SECRET_ACCESS_KEY: "mockSecretAccessKey",
         AWS_SESSION_TOKEN: "mockSessionToken"
     };
-
+    process.env.AWS_PROFILE = "development-eu-west-2";
     beforeAll(async () => {
 
         tmpDir = mkdtempSync(join(tmpdir(), "docker-compose"));


### PR DESCRIPTION
- Explicitly specify a valid AWS profile to regenerate credentials. Using `aws configure export-credentials` without --profile defaults to credentials that are expired and cannot be refreshed.