### PR TITLE
CC-2290: Add the OTEL feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,13 +653,21 @@ Brings up the docker-chs-development environment
 
 ```
 USAGE
-  $ chs-dev up
+  $ chs-dev up [--otel] [--no-otel]
+
+FLAGS
+  --no-otel  Disable OpenTelemetry for tracing
+  --otel     Enable OpenTelemetry for tracing
 
 DESCRIPTION
   Brings up the docker-chs-development environment
 
 EXAMPLES
   $ chs-dev up
+
+  $ chs-dev up --otel
+
+  $ chs-dev up --no-otel
 ```
 <!-- commandsstop -->
 

--- a/README.md
+++ b/README.md
@@ -669,6 +669,10 @@ EXAMPLES
 
   $ chs-dev up --no-otel
 ```
+
+DOCUMENTATION
+OpenTelemetry is a framework for collecting and exporting traces, metrics, and logs to observe services in chs-dev. When enabled, service logs and metrics can be processed and viewed in the [Grafana interface](http://api.chs.local/grafana).
+[Link to the Opentelemetry documentation](https://companieshouse.atlassian.net/wiki/spaces/TP/pages/5369659489/OpenTelemetry+Instrumenting+Services+with+docker-chs-development)
 <!-- commandsstop -->
 
 ## chs-dev Configuration

--- a/src/generator/docker-compose-file-generator.ts
+++ b/src/generator/docker-compose-file-generator.ts
@@ -48,7 +48,7 @@ export class DockerComposeFileGenerator extends AbstractFileGenerator {
      * @param builderVersion - Optional builder version.
      * @param excludedServices - List of excluded service names.
      */
-    // Create the development compose file and touch files
+    // Create the development compose file
     generateDevelopmentServiceDockerComposeFile (service: Service, builderVersion: string | undefined, excludedServices: string[] = []) {
         const developmentServicePath = join(this.path, "local", service.name);
 
@@ -74,7 +74,7 @@ export class DockerComposeFileGenerator extends AbstractFileGenerator {
             dockerComposeConfig, service
         );
 
-        // Create the development compose file and touch files
+        // Create the development compose file
         this.writeFile(
             yaml.stringify(developmentDockerComposeSpec).split(EOL),
             EOL,

--- a/src/generator/otel-generator.ts
+++ b/src/generator/otel-generator.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from "fs";
+import { EOL } from "os";
+import { join } from "path";
+import yaml from "yaml";
+import { getGeneratedDockerComposeFile } from "../helpers/docker-compose-file.js";
+import CONSTANTS from "../model/Constants.js";
+import { DockerComposeSpec } from "../model/DockerComposeSpec.js";
+import { AbstractFileGenerator } from "./file-generator.js";
+
+/**
+ * OtelGenerator is responsible for modifying the generated Docker Compose file
+ * to include or exclude OpenTelemetry (OTEL) services based on the provided flags.
+ */
+export class OtelGenerator extends AbstractFileGenerator {
+
+    constructor (path: string) {
+        super(path, "docker-compose.yaml");
+    }
+
+    /**
+     * Modifies the generated Docker Compose file to include or exclude OpenTelemetry (OTEL) services based on the provided flags.
+     *
+     * @param flag - An object containing the OTEL flag and its negation.
+     */
+    modifyGeneratedDockerCompose (flag: Record<string, boolean> | undefined): void {
+        const flagOption = Object.keys(flag || {});
+
+        let generatedDockerCompose: DockerComposeSpec | undefined;
+
+        if (flagOption.includes("otel")) {
+            generatedDockerCompose = this.modifyIncludeProperties("add");
+            generatedDockerCompose = this.modifyDependencies(generatedDockerCompose, "add");
+        } else if (flagOption.includes("no-otel") || flagOption.length === 0) {
+            generatedDockerCompose = this.modifyIncludeProperties("remove");
+            generatedDockerCompose = this.modifyDependencies(generatedDockerCompose, "remove");
+        }
+
+        this.writeFile(
+            yaml.stringify(generatedDockerCompose).split(EOL),
+            EOL
+        );
+    }
+
+    get otelServiceNames () {
+        return Object.keys(this.getOtelServices()).filter(serviceName => serviceName !== "init");
+    }
+
+    private getOtelServices (): Record<string, any> {
+        return yaml.parse(readFileSync(this.getOtelDockerComposeFilePath(), "utf8")).services;
+    }
+
+    private getOtelDockerComposeFilePath (): string {
+        return join(this.path, CONSTANTS.OTEL_DOCKER_COMPOSE_FILE);
+    }
+
+    /**
+     * Modifies the `include` property of the generated Docker Compose specification
+     * by adding or removing the OTEL Docker Compose file path.
+     *
+     * @param action - "add" to include the OTEL Docker Compose file, "remove" to exclude it.
+     * @returns {DockerComposeSpec} - The updated Docker Compose specification.
+     */
+    private modifyIncludeProperties (action: "add" | "remove"): DockerComposeSpec {
+        const generatedDockerCompose = getGeneratedDockerComposeFile(this.path);
+        const otelDockerComposeFilePath = this.getOtelDockerComposeFilePath();
+
+        if (action === "add") {
+            generatedDockerCompose.include = [
+                otelDockerComposeFilePath,
+                ...(generatedDockerCompose.include ?? []).filter(path => path !== otelDockerComposeFilePath)
+            ];
+        } else {
+            generatedDockerCompose.include = generatedDockerCompose.include?.filter((path) => path !== otelDockerComposeFilePath) || [];
+        }
+        return generatedDockerCompose;
+    }
+
+    /**
+     * Modifies the `depends_on` property of the generated Docker Compose specification
+     * by adding or removing the OTEL services.
+     *
+     * @param action - "add" to include the OTEL services, "remove" to exclude it.
+     * @returns {DockerComposeSpec} - The updated Docker Compose specification.
+     */
+    private modifyDependencies (generatedDockerCompose: DockerComposeSpec, action: "add" | "remove"): DockerComposeSpec {
+        const otelServiceNames = this.otelServiceNames;
+
+        const dependsOn = generatedDockerCompose.services["ingress-proxy"].depends_on || {};
+
+        if (action === "add") {
+            const otelIngressDependsOn = Object.fromEntries(
+                otelServiceNames.map((serviceName) => [
+                    serviceName,
+                    {
+                        condition: "service_started",
+                        restart: true
+                    }
+                ])
+            );
+            generatedDockerCompose.services["ingress-proxy"].depends_on = {
+                ...dependsOn,
+                ...otelIngressDependsOn
+            };
+        } else {
+            for (const serviceName of otelServiceNames) {
+                delete dependsOn[serviceName];
+            }
+            generatedDockerCompose.services["ingress-proxy"].depends_on = dependsOn;
+        }
+
+        return generatedDockerCompose;
+    }
+}

--- a/src/generator/otel-generator.ts
+++ b/src/generator/otel-generator.ts
@@ -22,15 +22,14 @@ export class OtelGenerator extends AbstractFileGenerator {
      *
      * @param flag - An object containing the OTEL flag and its negation.
      */
-    modifyGeneratedDockerCompose (flag: Record<string, boolean> | undefined): void {
-        const flagOption = Object.keys(flag || {});
+    modifyGeneratedDockerCompose (flag: Record<string, boolean>): void {
 
         let generatedDockerCompose: DockerComposeSpec | undefined;
 
-        if (flagOption.includes("otel")) {
+        if (flag.otel) {
             generatedDockerCompose = this.modifyIncludeProperties("add");
             generatedDockerCompose = this.modifyDependencies(generatedDockerCompose, "add");
-        } else if (flagOption.includes("no-otel") || flagOption.length === 0) {
+        } else if (flag["no-otel"] || !flag.otel) {
             generatedDockerCompose = this.modifyIncludeProperties("remove");
             generatedDockerCompose = this.modifyDependencies(generatedDockerCompose, "remove");
         }

--- a/src/helpers/docker-compose-file.ts
+++ b/src/helpers/docker-compose-file.ts
@@ -15,3 +15,16 @@ export const getInitialDockerComposeFile = (path: string): DockerComposeSpec => 
         readFileSync(join(path, CONSTANTS.BASE_DOCKER_COMPOSE_FILE), "utf8").toString()
     );
 };
+
+/**
+ * Get the generated main compose file content
+ *
+ * @param path - default compose file path location
+ * @returns a yaml format of the compose file
+ */
+export const getGeneratedDockerComposeFile = (path: string): DockerComposeSpec => {
+    const generatedDockerComposePath = join(path, `docker-compose.yaml`);
+    return yaml.parse(
+        readFileSync(generatedDockerComposePath, "utf8").toString()
+    );
+};

--- a/src/hooks/check-development-service-config.ts
+++ b/src/hooks/check-development-service-config.ts
@@ -19,7 +19,7 @@ export const hook: Hook<"check-development-service-config"> = async ({ services,
     for (const service of services) {
         if (service.builder === "node") {
             checkNodeServiceConfig(service, projectPath, context);
-        } else if (service.builder.includes("java") || !service.builder) {
+        } else if (service.builder.includes("java") || service.builder.includes("repository")) {
             checkServiceHealthCheckConfig(service, context);
         }
     }

--- a/src/model/Constants.ts
+++ b/src/model/Constants.ts
@@ -9,6 +9,11 @@ export const CONSTANTS = {
     BASE_DOCKER_COMPOSE_FILE: "services/infrastructure/docker-compose.yaml",
 
     /**
+     * The otel Docker Compose Spec
+     */
+    OTEL_DOCKER_COMPOSE_FILE: "services/infrastructure/open-telemetry/open-telemetry.docker-compose.yaml",
+
+    /**
      * Value for a boolean label to be considered true
      */
     BOOLEAN_LABEL_TRUE_VALUE: "true",

--- a/src/run/troubleshoot/analysis/VersionAnalysis.ts
+++ b/src/run/troubleshoot/analysis/VersionAnalysis.ts
@@ -14,7 +14,7 @@ interface VersionComplianceIssues {
 const ANALYSIS_HEADLINE = "Checks chs-dev version";
 
 const VERSION_SUGGESTIONS = [
-    "Run: chs-dev sync to update chs-dev to a suitable version. Refer to the documentation for guidance."
+    "Run: 'chs-dev sync --latest' to update chs-dev to a suitable version. Refer to the documentation for guidance."
 ];
 
 const DOCUMENTATION_LINKS = [

--- a/test/commands/__snapshots__/status.spec.ts.snap
+++ b/test/commands/__snapshots__/status.spec.ts.snap
@@ -60,7 +60,87 @@ exports[`Status command should log json correctly 1`] = `
 ]
 `;
 
-exports[`Status command should log with their docker compose statuses correctly 1`] = `
+exports[`Status command should log with their docker compose statuses with otel services 1`] = `
+[
+  [
+    "Manually activated modules:",
+  ],
+  [
+    " - module-one",
+  ],
+  [
+    "
+Manually activated services:",
+  ],
+  [
+    " - service-one ([31m[1mUp 3 seconds (unhealthy)[22m[39m)",
+  ],
+  [
+    " - service-two ([32m[1mUp 2 minutes (healthy)[22m[39m)",
+  ],
+  [
+    " - service-five ([33mExited (0)[39m)",
+  ],
+  [
+    " - service-six ([31mExited (137)[39m)",
+  ],
+  [
+    " - service-seven ([32mUp 33 minutes[39m)",
+  ],
+  [
+    " - service-eight ([32mUp About an hour[39m)",
+  ],
+  [
+    " - service-three ([32m[1mUp About an hour (healthy)[22m[39m)",
+  ],
+  [
+    "
+Automatically activated services:",
+  ],
+  [
+    " - loki ([32mUp About an hour[39m) ",
+  ],
+  [
+    " - otel-collector ([32mUp About an hour[39m) ",
+  ],
+  [
+    " - service-eight ([32mUp About an hour[39m) ",
+  ],
+  [
+    " - service-five ([33mExited (0)[39m) ",
+  ],
+  [
+    " - service-four ([36mUp 1 minute (health: starting)[39m) ",
+  ],
+  [
+    " - service-one ([31m[1mUp 3 seconds (unhealthy)[22m[39m) ",
+  ],
+  [
+    " - service-seven ([32mUp 33 minutes[39m) ",
+  ],
+  [
+    " - service-six ([31mExited (137)[39m) ",
+  ],
+  [
+    " - service-three ([32m[1mUp About an hour (healthy)[22m[39m) ",
+  ],
+  [
+    " - service-two ([32m[1mUp 2 minutes (healthy)[22m[39m) [LIVE UPDATE]",
+  ],
+  [
+    " - tempo ([32mUp About an hour[39m) ",
+  ],
+  [
+    "
+Manually deactivated services:",
+  ],
+  [
+    " - service-three",
+  ],
+]
+`;
+
+exports[`Status command should log with their docker compose statuses without otel services 1`] = `
 [
   [
     "Manually activated modules:",

--- a/test/generator/otel-generator.spec.ts
+++ b/test/generator/otel-generator.spec.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { OtelGenerator } from "../../src/generator/otel-generator";
+import { DockerComposeSpec } from "../../src/model/DockerComposeSpec";
+
+import * as path from "path";
+import * as yaml from "yaml";
+
+jest.mock("fs");
+jest.mock("yaml");
+
+const CONSTANTSMOCK = {
+    OTEL_DOCKER_COMPOSE_FILE: "services/infrastructure/open-telemetry/open-telemetry.docker-compose.yaml"
+};
+
+const mockDockerCompose: DockerComposeSpec = {
+    include: [],
+    services: {
+        "ingress-proxy": {
+            depends_on: {}
+        }
+    }
+};
+
+jest.mock("../../src/helpers/docker-compose-file", () => ({
+    getGeneratedDockerComposeFile: jest.fn(() => mockDockerCompose)
+}));
+
+describe("OtelGenerator", () => {
+    let otelGenerator: OtelGenerator;
+    const testPath = "/tmp/test";
+    let mockOtelServices: Record<string, any>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        otelGenerator = new OtelGenerator(testPath);
+        mockOtelServices = {
+            services: {
+                "otel-collector": { depends_on: [] },
+                loki: { depends_on: [] },
+                tempo: { depends_on: [] },
+                init: {}
+            }
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should include OTEL services when otel flag is true", () => {
+        mockDockerCompose.include = [path.join(testPath, CONSTANTSMOCK.OTEL_DOCKER_COMPOSE_FILE)];
+        (otelGenerator as any).modifyIncludeProperties = jest.fn().mockReturnValue(mockDockerCompose);
+        mockDockerCompose.services["ingress-proxy"].depends_on = {
+            "otel-collector": { condition: "service_started", restart: true },
+            loki: { condition: "service_started", restart: true },
+            tempo: { condition: "service_started", restart: true }
+        };
+        (otelGenerator as any).modifyDependencies = jest.fn().mockReturnValue(mockDockerCompose);
+        (otelGenerator as any).writeFile = jest.fn();
+        (yaml.stringify as jest.Mock).mockReturnValue("mock-yaml-content");
+
+        otelGenerator.modifyGeneratedDockerCompose({ otel: true });
+
+        expect((otelGenerator as any).modifyIncludeProperties).toHaveBeenCalledWith("add");
+        expect((otelGenerator as any).modifyDependencies).toHaveBeenCalledWith(mockDockerCompose, "add");
+        expect((otelGenerator as any).writeFile).toHaveBeenCalled();
+    });
+
+    it("should exclude OTEL services when no-otel flag is true", () => {
+        (otelGenerator as any).modifyIncludeProperties = jest.fn().mockReturnValue(mockDockerCompose);
+        (otelGenerator as any).modifyDependencies = jest.fn().mockReturnValue(mockDockerCompose);
+        (otelGenerator as any).writeFile = jest.fn();
+        (yaml.stringify as jest.Mock).mockReturnValue("mock-yaml-content");
+
+        otelGenerator.modifyGeneratedDockerCompose({ "no-otel": true });
+
+        expect((otelGenerator as any).modifyIncludeProperties).toHaveBeenCalledWith("remove");
+        expect((otelGenerator as any).modifyDependencies).toHaveBeenCalledWith(mockDockerCompose, "remove");
+        expect((otelGenerator as any).writeFile).toHaveBeenCalled();
+    });
+
+    it("should exclude OTEL services when no flag is set", () => {
+        (otelGenerator as any).modifyIncludeProperties = jest.fn().mockReturnValue(mockDockerCompose);
+        (otelGenerator as any).modifyDependencies = jest.fn().mockReturnValue(mockDockerCompose);
+        (otelGenerator as any).writeFile = jest.fn();
+        (yaml.stringify as jest.Mock).mockReturnValue("mock-yaml-content");
+
+        otelGenerator.modifyGeneratedDockerCompose(undefined);
+
+        expect((otelGenerator as any).modifyIncludeProperties).toHaveBeenCalledWith("remove");
+        expect((otelGenerator as any).modifyDependencies).toHaveBeenCalledWith(mockDockerCompose, "remove");
+        expect((otelGenerator as any).writeFile).toHaveBeenCalled();
+    });
+
+    it("should return otel service names except 'init'", () => {
+        (yaml.parse as jest.Mock).mockReturnValue(
+            mockOtelServices
+        );
+        expect(otelGenerator.otelServiceNames).toEqual(["otel-collector", "loki", "tempo"]);
+    });
+
+    it("should get OTEL services from file", () => {
+        (yaml.parse as jest.Mock).mockReturnValue(
+            mockOtelServices
+        );
+        const services = (otelGenerator as any).getOtelServices();
+        expect(services).toEqual(mockOtelServices.services);
+    });
+
+    it("should get OTEL docker compose file path", () => {
+        const filePath = (otelGenerator as any).getOtelDockerComposeFilePath();
+        expect(filePath).toBe(path.join(testPath, CONSTANTSMOCK.OTEL_DOCKER_COMPOSE_FILE));
+    });
+
+    it("should add OTEL services to depends_on when action is 'add'", () => {
+        (yaml.parse as jest.Mock).mockReturnValue(
+            mockOtelServices
+        );
+        const result = (otelGenerator as any).modifyDependencies(mockDockerCompose, "add");
+        expect(result.services["ingress-proxy"].depends_on["otel-collector"]).toBeDefined();
+        expect(result.services["ingress-proxy"].depends_on.loki).toBeDefined();
+        expect(result.services["ingress-proxy"].depends_on.tempo).toBeDefined();
+    });
+
+    it("should remove OTEL services from depends_on when action is 'remove'", () => {
+        (yaml.parse as jest.Mock).mockReturnValue(
+            mockOtelServices
+        );
+        mockDockerCompose.services["ingress-proxy"].depends_on = {
+            "otel-collector": { condition: "service_started", restart: true },
+            loki: { condition: "service_started", restart: true },
+            tempo: { condition: "service_started", restart: true }
+        };
+        const result = (otelGenerator as any).modifyDependencies(mockDockerCompose, "remove");
+        expect(result.services["ingress-proxy"].depends_on["otel-collector"]).toBeUndefined();
+        expect(result.services["ingress-proxy"].depends_on.loki).toBeUndefined();
+        expect(result.services["ingress-proxy"].depends_on.tempo).toBeUndefined();
+    });
+
+    it("should add otel docker compose file to include when action is 'add'", () => {
+        const result = (otelGenerator as any).modifyIncludeProperties("add");
+
+        expect(result.include).toContain(path.join(testPath, CONSTANTSMOCK.OTEL_DOCKER_COMPOSE_FILE));
+    });
+
+    it("should remove otel docker compose file from include when action is 'remove'", () => {
+        mockDockerCompose.include = [path.join(testPath, CONSTANTSMOCK.OTEL_DOCKER_COMPOSE_FILE)];
+
+        const result = (otelGenerator as any).modifyIncludeProperties("remove");
+        expect(result.include).not.toContain(path.join(testPath, CONSTANTSMOCK.OTEL_DOCKER_COMPOSE_FILE));
+    });
+});

--- a/test/generator/otel-generator.spec.ts
+++ b/test/generator/otel-generator.spec.ts
@@ -85,7 +85,7 @@ describe("OtelGenerator", () => {
         (otelGenerator as any).writeFile = jest.fn();
         (yaml.stringify as jest.Mock).mockReturnValue("mock-yaml-content");
 
-        otelGenerator.modifyGeneratedDockerCompose(undefined);
+        otelGenerator.modifyGeneratedDockerCompose({});
 
         expect((otelGenerator as any).modifyIncludeProperties).toHaveBeenCalledWith("remove");
         expect((otelGenerator as any).modifyDependencies).toHaveBeenCalledWith(mockDockerCompose, "remove");

--- a/test/helpers/docker-compose-file.spec.ts
+++ b/test/helpers/docker-compose-file.spec.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, expect, jest } from "@jest/globals";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { getInitialDockerComposeFile } from "../../src/helpers/docker-compose-file"; // A
+import { getInitialDockerComposeFile, getGeneratedDockerComposeFile } from "../../src/helpers/docker-compose-file"; // A
 
 jest.mock("fs");
 
@@ -28,10 +28,16 @@ describe("docker-compose-file", () => {
         rmSync(MOCK_DIR, { recursive: true, force: true });
     });
 
-    describe("getInitialDockerComposeFile", () => {
-        it("should parse a Docker Compose YAML file correctly", () => {
+    describe("get Initial or Generated DockerComposeFile", () => {
+        it("should parse Initial Docker Compose YAML file correctly", () => {
             (readFileSync as jest.Mock).mockReturnValue(JSON.stringify(MOCK_FILE_CONTENT));
             const result = getInitialDockerComposeFile(MOCK_DIR);
+            expect(result).toEqual(MOCK_FILE_CONTENT);
+        });
+
+        it("should parse Generated Docker Compose YAML file correctly", () => {
+            (readFileSync as jest.Mock).mockReturnValue(JSON.stringify(MOCK_FILE_CONTENT));
+            const result = getGeneratedDockerComposeFile(MOCK_DIR);
             expect(result).toEqual(MOCK_FILE_CONTENT);
         });
     });

--- a/test/run/troubleshoot/analysis/VersionAnalysis.spec.ts
+++ b/test/run/troubleshoot/analysis/VersionAnalysis.spec.ts
@@ -12,7 +12,7 @@ jest.mock("semver", () => ({
 describe("VersionAnalysis", () => {
     let analysis: VersionAnalysis;
     const VERSION_SUGGESTIONS = [
-        "Run: chs-dev sync to update chs-dev to a suitable version. Refer to the documentation for guidance."
+        "Run: 'chs-dev sync --latest' to update chs-dev to a suitable version. Refer to the documentation for guidance."
     ];
 
     beforeEach(async () => {


### PR DESCRIPTION
Update the chs-dev up command to support two flags — --otel and --no-otel — allowing users to enable or disable the activation of OpenTelemetry (Otel) services.

Example Commands
- `chs-dev up`
- `chs-dev up --otel`
- `chs-dev up --no-otel`

[Add OTEL flag to chs-dev up command](https://github.com/companieshouse/chs-dev/commit/cbec1308364cee3e90b3fca01f09528dec0ad210) 

- Include flags to the `chs-dev up` command to enable and disable otel services.
- Modify the `chs-dev status` command to track Otel services status.
- Update ReadMe
- Update and Add unit test cases
- Refactor the versionAnalysis suggestion message for better user experience