### PR TITLE
CC-2186: Feature/troubleshoot tls handshake error

### DIFF
--- a/docs/troubleshooting-remedies/correctly-set-docker-compose-parallel-limit-variable.md
+++ b/docs/troubleshooting-remedies/correctly-set-docker-compose-parallel-limit-variable.md
@@ -16,5 +16,5 @@ Setting: `COMPOSE_PARALLEL_LIMIT=1`  forces Docker Compose to start services one
 
 ## Rationale
 
-This prevent resource contention which happens when there are too many processes competing for network access through the vpn.
+This prevents resource contention which happens when there are too many processes competing for network access through the vpn.
 

--- a/docs/troubleshooting-remedies/correctly-set-docker-compose-parallel-limit-variable.md
+++ b/docs/troubleshooting-remedies/correctly-set-docker-compose-parallel-limit-variable.md
@@ -1,0 +1,20 @@
+# Correctly set Docker Compose Parallel limit Variable
+
+## Problem Summary
+
+By default, Docker Compose starts multiple services in parallel to speed up the process. However, in some environments (especially on resource-constrained machines or CI pipelines), this can cause issues like -:
+ - TLS handshake time out when pulling/downloading images from ECR
+ - High CPU or memory usage
+ - Services failing to start because dependencies aren’t ready yet
+
+## Resolution Summary
+
+1. Open your terminal.
+2. Run:`COMPOSE_PARALLEL_LIMIT=1 chs-dev up`.
+
+Setting: `COMPOSE_PARALLEL_LIMIT=1`  forces Docker Compose to start services one at a time, serially, instead of in parallel.
+
+## Rationale
+
+This prevent resource contention which happens when there are too many processes competing for network access through the vpn.
+

--- a/src/run/troubleshoot/analysis/TLSHandshakeAnalysis.ts
+++ b/src/run/troubleshoot/analysis/TLSHandshakeAnalysis.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import BaseAnalysis from "./AbstractBaseAnalysis.js";
+import AnalysisOutcome from "./AnalysisOutcome.js";
+import { AnalysisIssue, TroubleshootAnalysisTaskContext } from "./AnalysisTask.js";
+
+const ANALYSIS_HEADLINE = "Checks TLS Handshake Timeout Errors and enforce proper COMPOSE_PARALLEL_LIMIT configuration";
+
+const SUGGESTIONS = [
+    "Run: `COMPOSE_PARALLEL_LIMIT=1 chs-dev up`",
+    "to resolve the issue then",
+    "Run: 'rm -r ./local/.logs/' to clear logs."
+];
+
+const DOCUMENTATION_LINKS = [
+    "troubleshooting-remedies/correctly-set-docker-compose-parallel-limit-variable.md"
+];
+
+/**
+ * An analysis task that evaluates whether the logs shows a TLS handshake timeout error and suggest a resolution.
+ */
+export default class TLSHandshake extends BaseAnalysis {
+
+    async analyse ({ config: { projectPath } }: TroubleshootAnalysisTaskContext): Promise<AnalysisOutcome> {
+        const tlsIssue = this.checkDockerLogsForTLSHandshakeTimeoutError(projectPath);
+
+        return this.createOutcomeFrom(ANALYSIS_HEADLINE, tlsIssue, "Fail");
+    }
+
+    /**
+     * Checks the Docker logs for TLS handshake timeout errors.
+     * @param {string} projectPath - Path to the project repository
+     * @returns { Promise<AnalysisIssue | undefined> } - an AnalysisIssue if such an error is found in the last 5 log lines, otherwise undefined.
+     */
+    private checkDockerLogsForTLSHandshakeTimeoutError (projectPath): AnalysisIssue | undefined {
+        const currentDate = new Date().toISOString().slice(0, 10);
+        const daylogFile = `local/.logs/compose.out.${currentDate}.txt`;
+        const localLogs = join(projectPath, daylogFile);
+        const logContent = readFileSync(localLogs, "utf-8");
+
+        // Extract the last 5 log lines
+        const logLines = logContent.trim().split("\n");
+        const last5LogOutput = logLines.slice(-5).join("\n");
+        if (last5LogOutput.includes("TLS handshake timeout")) {
+
+            return this.createIssue(
+                "TLS Handshake Error Found in Docker Logs",
+                "Ensure 'COMPOSE_PARALLEL_LIMIT' environment variable is set to 1. This is necessary to avoid TLS handshake timeout errors when running multiple services in parallel.",
+                SUGGESTIONS,
+                DOCUMENTATION_LINKS
+            );
+        }
+        return undefined;
+    }
+
+}

--- a/src/run/troubleshoot/analysis/analysis-tasks.ts
+++ b/src/run/troubleshoot/analysis/analysis-tasks.ts
@@ -7,6 +7,7 @@ import PortAnalysis from "./PortAnalysis.js";
 import ProxiesConfiguredCorrectlyAnalysis from "./ProxiesConfiguredCorrectlyAnalysis.js";
 import ServicesInLiveUpdateConfiguredCorrectlyAnalysis from "./ServicesInLiveUpdateConfiguredCorrectlyAnalysis.js";
 import SSHAnalysis from "./SSHAnalysis.js";
+import TLSHandshake from "./TLSHandshakeAnalysis.js";
 import VersionAnalysis from "./VersionAnalysis.js";
 
 const analysisTasks: AnalysisTask[] = [
@@ -18,7 +19,8 @@ const analysisTasks: AnalysisTask[] = [
     new PortAnalysis(),
     new DockerChsDevelopmentVersionAnalysis(),
     new AwsEnvironmentVariableAnalysis(),
-    new SSHAnalysis()
+    new SSHAnalysis(),
+    new TLSHandshake()
 ];
 
 export default analysisTasks;

--- a/test/run/troubleshoot/analysis/TLSHandshakeAnalysis.spec.ts
+++ b/test/run/troubleshoot/analysis/TLSHandshakeAnalysis.spec.ts
@@ -27,12 +27,7 @@ describe("TLSHandshakeAnalysis", () => {
     );
 
     beforeEach(async () => {
-        jest.spyOn(global, "Date").mockImplementation(() =>
-            ({
-                toISOString: () => `${mockDate}T12:00:00.000Z`
-            } as unknown as Date)
-        );
-
+        jest.useFakeTimers().setSystemTime(new Date(`${mockDate}T12:00:00.000Z`));
         analysis = new TLSHandshakeAnalysis();
         jest.resetAllMocks();
     });
@@ -65,36 +60,33 @@ describe("TLSHandshakeAnalysis", () => {
         );
     });
 
-    // it("should return an AnalysisOutcome with no issues if TLS handshake timeout is not found", async () => {
-    //     const logContent = [
-    //         "Some log line",
-    //         "Another log line",
-    //         "No handshake error here",
-    //         "Yet another log line",
-    //         "Final log line"
-    //     ].join("\n");
+    it("should return an AnalysisOutcome with no issues if TLS handshake timeout is not found", async () => {
+        const logContent = [
+            "Some log line",
+            "Another log line",
+            "No handshake error here",
+            "Yet another log line",
+            "Final log line"
+        ].join("\n");
 
-    //     (fs.readFileSync as jest.Mock).mockReturnValue(logContent);
+        (fs.readFileSync as jest.Mock).mockReturnValue(logContent);
 
-    //     const tlsHandshake = new TLSHandshake();
-    //     const outcome = await tlsHandshake.analyse({
-    //         config: { projectPath: mockProjectPath }
-    //     } as any);
+        const outcome = await analysis.analyse({
+            config: { projectPath: mockProjectPath }
+        } as any);
 
-    //     expect(fs.readFileSync).toHaveBeenCalledWith(mockLogPath, "utf-8");
-    //     expect(outcome.headline).toContain("TLS Handshake Timeout Errors");
-    //     expect(outcome.issues).toHaveLength(0);
-    //     expect(outcome.status).toBe("Fail");
-    // });
+        expect(fs.readFileSync).toHaveBeenCalledWith(mockLogPath, "utf-8");
+        expect(outcome.headline).toContain("TLS Handshake Timeout Errors");
+        expect(outcome.issues).toHaveLength(0);
+    });
 
-    // it("should handle empty log files gracefully", async () => {
-    //     (fs.readFileSync as jest.Mock).mockReturnValue("");
+    it("should handle empty log files gracefully", async () => {
+        (fs.readFileSync as jest.Mock).mockReturnValue("");
 
-    //     const tlsHandshake = new TLSHandshake();
-    //     const outcome = await tlsHandshake.analyse({
-    //         config: { projectPath: mockProjectPath }
-    //     } as any);
+        const outcome = await analysis.analyse({
+            config: { projectPath: mockProjectPath }
+        } as any);
 
-    //     expect(outcome.issues).toHaveLength(0);
-    // });
+        expect(outcome.issues).toHaveLength(0);
+    });
 });

--- a/test/run/troubleshoot/analysis/TLSHandshakeAnalysis.spec.ts
+++ b/test/run/troubleshoot/analysis/TLSHandshakeAnalysis.spec.ts
@@ -1,0 +1,100 @@
+import { expect, jest } from "@jest/globals";
+import AnalysisOutcome from "../../../../src/run/troubleshoot/analysis/AnalysisOutcome";
+import { TroubleshootAnalysisTaskContext } from "../../../../src/run/troubleshoot/analysis/AnalysisTask";
+import * as fs from "fs";
+import TLSHandshakeAnalysis from "../../../../src/run/troubleshoot/analysis/TLSHandshakeAnalysis";
+import { join } from "path";
+
+jest.mock("fs");
+
+const SUGGESTIONS = [
+    "Run: `COMPOSE_PARALLEL_LIMIT=1 chs-dev up`",
+    "to resolve the issue then",
+    "Run: 'rm -r ./local/.logs/' to clear logs."
+];
+const DOCUMENTATION_LINKS = [
+    "troubleshooting-remedies/correctly-set-docker-compose-parallel-limit-variable.md"
+];
+
+describe("TLSHandshakeAnalysis", () => {
+    let analysis: TLSHandshakeAnalysis;
+
+    const mockProjectPath = "/mock/project";
+    const mockDate = "2025-06-16";
+    const mockLogPath = join(
+        mockProjectPath,
+        `local/.logs/compose.out.${mockDate}.txt`
+    );
+
+    beforeEach(async () => {
+        jest.spyOn(global, "Date").mockImplementation(() =>
+            ({
+                toISOString: () => `${mockDate}T12:00:00.000Z`
+            } as unknown as Date)
+        );
+
+        analysis = new TLSHandshakeAnalysis();
+        jest.resetAllMocks();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return an AnalysisOutcome with issue if TLS handshake timeout is found", async () => {
+        const logContent = [
+            "Some log line",
+            "Another log line",
+            "TLS handshake timeout",
+            "Yet another log line",
+            "Final log line"
+        ].join("\n");
+
+        (fs.readFileSync as jest.Mock).mockReturnValue(logContent);
+
+        const outcome = await analysis.analyse({
+            config: { projectPath: mockProjectPath }
+        } as any);
+
+        expect(fs.readFileSync).toHaveBeenCalledWith(mockLogPath, "utf-8");
+        expect(outcome.headline).toContain("TLS Handshake Timeout Errors");
+        expect(outcome.issues).toHaveLength(1);
+        expect(outcome.issues[0].title).toContain("TLS Handshake Error");
+        expect(outcome.issues[0].suggestions).toContain(
+            "Run: `COMPOSE_PARALLEL_LIMIT=1 chs-dev up`"
+        );
+    });
+
+    // it("should return an AnalysisOutcome with no issues if TLS handshake timeout is not found", async () => {
+    //     const logContent = [
+    //         "Some log line",
+    //         "Another log line",
+    //         "No handshake error here",
+    //         "Yet another log line",
+    //         "Final log line"
+    //     ].join("\n");
+
+    //     (fs.readFileSync as jest.Mock).mockReturnValue(logContent);
+
+    //     const tlsHandshake = new TLSHandshake();
+    //     const outcome = await tlsHandshake.analyse({
+    //         config: { projectPath: mockProjectPath }
+    //     } as any);
+
+    //     expect(fs.readFileSync).toHaveBeenCalledWith(mockLogPath, "utf-8");
+    //     expect(outcome.headline).toContain("TLS Handshake Timeout Errors");
+    //     expect(outcome.issues).toHaveLength(0);
+    //     expect(outcome.status).toBe("Fail");
+    // });
+
+    // it("should handle empty log files gracefully", async () => {
+    //     (fs.readFileSync as jest.Mock).mockReturnValue("");
+
+    //     const tlsHandshake = new TLSHandshake();
+    //     const outcome = await tlsHandshake.analyse({
+    //         config: { projectPath: mockProjectPath }
+    //     } as any);
+
+    //     expect(outcome.issues).toHaveLength(0);
+    // });
+});


### PR DESCRIPTION
By default, Docker Compose starts multiple services in parallel to speed up the process. However, in some environments (especially on resource-constrained machines or CI pipelines), this can cause issues like -:
 - TLS handshake time out when pulling/downloading images from ECR
 - High CPU or memory usage
 - Services failing to start because dependencies aren’t ready yet
 
 Setting: `COMPOSE_PARALLEL_LIMIT=1` forces Docker Compose to start services one at a time, serially, instead of in parallel.

[Add TLS Handshake Analysis to troubleshooting task](https://github.com/companieshouse/chs-dev/commit/5874475bbeea7a02c7a5220019d576263055be9d) 

- Guide user on how to resolve the TLS handshake time out error.
- add documentation
- add unit test case