### PR TITLE
Feature/add clean cache chs state

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ USAGE
 * [`chs-dev services available`](#chs-dev-services-available)
 * [`chs-dev services disable SERVICES`](#chs-dev-services-disable-services)
 * [`chs-dev services enable SERVICES`](#chs-dev-services-enable-services)
+* [`chs-dev state clean`](#chs-dev-state-clean)
 * [`chs-dev status`](#chs-dev-status)
 * [`chs-dev sync`](#chs-dev-sync)
 * [`chs-dev troubleshoot analyse [OUTPUTFILE]`](#chs-dev-troubleshoot-analyse-outputfile)
@@ -566,6 +567,18 @@ ARGUMENTS
 
 DESCRIPTION
   Enables the services and any dependencies for use within the Docker environment
+```
+
+## `chs-dev state clean`
+
+Wipes the state of chs-dev and revert to a default state
+
+```
+USAGE
+  $ chs-dev state clean
+
+DESCRIPTION
+  Wipes the state of chs-dev and revert to a default state
 ```
 
 ## `chs-dev status`

--- a/README.md
+++ b/README.md
@@ -576,10 +576,15 @@ Cache the state of chs-dev into a saved file
 
 ```
 USAGE
-  $ chs-dev state cache [NAME]
+  $ chs-dev state cache [NAME] [-w] [-r] [-a]
 
 ARGUMENTS
   NAME  Name of the cache
+
+FLAGS
+  -a, --available  Show the name of the saved states in a available
+  -r, --remove     Remove a specific saved cache
+  -w, --wipe       Delete all saved caches
 
 DESCRIPTION
   Cache the state of chs-dev into a saved file

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ USAGE
 * [`chs-dev services enable SERVICES`](#chs-dev-services-enable-services)
 * [`chs-dev state cache [NAME]`](#chs-dev-state-cache-name)
 * [`chs-dev state clean`](#chs-dev-state-clean)
+* [`chs-dev state export NAME`](#chs-dev-state-export-name)
+* [`chs-dev state restore [NAME]`](#chs-dev-state-restore-name)
 * [`chs-dev status`](#chs-dev-status)
 * [`chs-dev sync`](#chs-dev-sync)
 * [`chs-dev troubleshoot analyse [OUTPUTFILE]`](#chs-dev-troubleshoot-analyse-outputfile)
@@ -576,15 +578,16 @@ Cache the state of chs-dev into a saved file
 
 ```
 USAGE
-  $ chs-dev state cache [NAME] [-w] [-r] [-a]
+  $ chs-dev state cache [NAME] [-w] [-r] [-a] [-e]
 
 ARGUMENTS
   NAME  Name of the cache
 
 FLAGS
-  -a, --available  Show the name of the saved states in a available
-  -r, --remove     Remove a specific saved cache
-  -w, --wipe       Delete all saved caches
+  -a, --available    List of saved states.
+  -e, --exportCache  Export a named cache to a file
+  -r, --remove       Remove a specific saved cache
+  -w, --wipe         Delete all saved caches
 
 DESCRIPTION
   Cache the state of chs-dev into a saved file
@@ -596,10 +599,46 @@ Wipes the state of chs-dev and revert to a default state
 
 ```
 USAGE
-  $ chs-dev state clean
+  $ chs-dev state clean [-p]
+
+FLAGS
+  -p, --purge  Wipe state, volumes and images
 
 DESCRIPTION
   Wipes the state of chs-dev and revert to a default state
+```
+
+## `chs-dev state export NAME`
+
+Export current state of chs-dev into a saved file
+
+```
+USAGE
+  $ chs-dev state export NAME
+
+ARGUMENTS
+  NAME  Name of the exported file
+
+DESCRIPTION
+  Export current state of chs-dev into a saved file
+```
+
+## `chs-dev state restore [NAME]`
+
+Restore and update the state files from saved cache or imported cache.
+
+```
+USAGE
+  $ chs-dev state restore [NAME] [-i <value>]
+
+ARGUMENTS
+  NAME  Name of the cache
+
+FLAGS
+  -i, --importCacheFrom=<value>  Path to the exported cache
+
+DESCRIPTION
+  Restore and update the state files from saved cache or imported cache.
 ```
 
 ## `chs-dev status`

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ USAGE
 * [`chs-dev services available`](#chs-dev-services-available)
 * [`chs-dev services disable SERVICES`](#chs-dev-services-disable-services)
 * [`chs-dev services enable SERVICES`](#chs-dev-services-enable-services)
+* [`chs-dev state cache [NAME]`](#chs-dev-state-cache-name)
 * [`chs-dev state clean`](#chs-dev-state-clean)
 * [`chs-dev status`](#chs-dev-status)
 * [`chs-dev sync`](#chs-dev-sync)
@@ -567,6 +568,21 @@ ARGUMENTS
 
 DESCRIPTION
   Enables the services and any dependencies for use within the Docker environment
+```
+
+## `chs-dev state cache [NAME]`
+
+Cache the state of chs-dev into a saved file
+
+```
+USAGE
+  $ chs-dev state cache [NAME]
+
+ARGUMENTS
+  NAME  Name of the cache
+
+DESCRIPTION
+  Cache the state of chs-dev into a saved file
 ```
 
 ## `chs-dev state clean`

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,6 +10,7 @@ import ExclusionsRemove from "./exclusions/remove.js";
 import DevelopmentServices from "./development/services.js";
 import DevelopmentEnable from "./development/enable.js";
 import StateClean from "./state/clean.js";
+import StateCache from "./state/cache.js";
 import DevelopmentDisable from "./development/disable.js";
 import ServicesAvailable from "./services/available.js";
 import ServiceEnable from "./services/enable.js";
@@ -30,6 +31,7 @@ export const commands = {
     sync: Sync,
     logs: Logs,
     "state:clean": StateClean,
+    "state:cache": StateCache,
     "compose-logs": ComposeLogs,
     "exclusions:list": ExclusionsList,
     "exclusions:add": ExclusionsAdd,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,7 @@ import ExclusionsAdd from "./exclusions/add.js";
 import ExclusionsRemove from "./exclusions/remove.js";
 import DevelopmentServices from "./development/services.js";
 import DevelopmentEnable from "./development/enable.js";
+import StateClean from "./state/clean.js";
 import DevelopmentDisable from "./development/disable.js";
 import ServicesAvailable from "./services/available.js";
 import ServiceEnable from "./services/enable.js";
@@ -28,6 +29,7 @@ export const commands = {
     up: Up,
     sync: Sync,
     logs: Logs,
+    "state:clean": StateClean,
     "compose-logs": ComposeLogs,
     "exclusions:list": ExclusionsList,
     "exclusions:add": ExclusionsAdd,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,6 +11,8 @@ import DevelopmentServices from "./development/services.js";
 import DevelopmentEnable from "./development/enable.js";
 import StateClean from "./state/clean.js";
 import StateCache from "./state/cache.js";
+import StateExport from "./state/export.js";
+import StateRestore from "./state/restore.js";
 import DevelopmentDisable from "./development/disable.js";
 import ServicesAvailable from "./services/available.js";
 import ServiceEnable from "./services/enable.js";
@@ -32,6 +34,8 @@ export const commands = {
     logs: Logs,
     "state:clean": StateClean,
     "state:cache": StateCache,
+    "state:export": StateExport,
+    "state:restore": StateRestore,
     "compose-logs": ComposeLogs,
     "exclusions:list": ExclusionsList,
     "exclusions:add": ExclusionsAdd,

--- a/src/commands/state/cache.ts
+++ b/src/commands/state/cache.ts
@@ -4,9 +4,12 @@ import ChsDevConfig from "../../model/Config.js";
 import loadConfig from "../../helpers/config-loader.js";
 import { DockerCompose } from "../../run/docker-compose.js";
 import { confirm } from "../../helpers/user-input.js";
+import { createHash } from "crypto";
+import yaml from "yaml";
+import { basename, join } from "path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 
 export default class Cache extends Command {
-
     static description = "Cache the state of chs-dev into a saved file";
 
     static args = {
@@ -16,34 +19,143 @@ export default class Cache extends Command {
         })
     };
 
+    static flags = {
+        wipe: Flags.boolean({
+            char: "w",
+            description: "Delete all saved caches"
+        }),
+        remove: Flags.boolean({
+            char: "r",
+            description: "Remove a specific saved cache"
+        }),
+        available: Flags.boolean({
+            char: "a",
+            description: "Show the name of the saved states in a available"
+        })
+    };
+
     private readonly stateManager: StateManager;
     private readonly chsDevConfig: ChsDevConfig;
     private readonly dockerCompose: DockerCompose;
+    private readonly stateCacheFile: string;
 
     constructor (argv: string[], config: Config) {
         super(argv, config);
 
-        const logger = {
-            log: (msg: string) => this.log(msg)
-        };
         this.chsDevConfig = loadConfig();
+        const cacheDir = config.cacheDir;
+        this.stateCacheFile = join(cacheDir, `${basename(this.chsDevConfig.projectName)}.state.yaml`);
+
+        if (!existsSync(cacheDir)) {
+            mkdirSync(cacheDir, { recursive: true });
+        }
+
+        const logger = { log: (msg: string) => this.log(msg) };
+
         this.stateManager = new StateManager(this.chsDevConfig.projectPath);
         this.dockerCompose = new DockerCompose(this.chsDevConfig, logger);
-
     }
 
-    async run (): Promise<any> {
-        const { args, flags } = await this.parse(Cache);
-        const timestamp: string = new Date(Date.now()).toISOString();
-        const cacheName: string = args.name || timestamp;
+    async run (): Promise<void> {
+        const { args, flags: { available, remove, wipe } } = await this.parse(Cache);
 
-        const handlePrompt = async (): Promise<boolean> => {
-            return await confirm(`save chs-dev state?`);
-        };
+        if (wipe) {
+            await this.handleAction("Wipe", "wipe", "Wiped all caches");
+            return;
+        } else if (available) {
+            this.cacheActions("Available", "available");
+            return;
+        }
 
-        if (await handlePrompt()) {
-            //
+        const cacheName = args.name || this.error("Cache name is required");
+
+        if (remove) {
+            await this.handleAction(cacheName, "remove", `Removed cache ${cacheName}`);
+        } else {
+            await this.handleAction(cacheName, "add", `Saved cache ${cacheName}`);
         }
     }
 
+    private async handleAction (cacheName: string, action: "add" | "remove" | "wipe", successMessage: string): Promise<void> {
+        if (await this.handlePrompt(cacheName, action)) {
+            this.cacheActions(cacheName, action);
+            this.log(successMessage);
+        }
+    }
+
+    private cacheActions (cacheName: string, action: "add" | "remove" | "wipe" | "available"): void {
+        let cacheData: Record<string, any> = this.loadCacheData();
+
+        switch (action) {
+        case "add": {
+            const stateSnapshot = this.stateManager.snapshot;
+            const dockerComposeSnapshot = this.getDockerFile();
+            cacheData[cacheName] = {
+                state: {
+                    hash: this.hash(JSON.stringify(stateSnapshot)),
+                    snapshot: stateSnapshot
+                },
+                dockerCompose: {
+                    hash: this.hash(dockerComposeSnapshot.toString("utf-8")),
+                    snapshot: dockerComposeSnapshot
+                }
+
+            };
+            break;
+        }
+        case "remove":
+            delete cacheData[cacheName];
+            break;
+        case "wipe":
+            cacheData = {};
+            break;
+        case "available":
+            this.availableCaches(cacheData);
+            return;
+        }
+
+        this.saveCacheData(cacheData);
+    }
+
+    private loadCacheData (): Record<string, any> {
+        if (existsSync(this.stateCacheFile)) {
+            const fileContent = yaml.parse(readFileSync(this.stateCacheFile, "utf-8"));
+            return fileContent || {};
+        }
+        return {};
+    }
+
+    private saveCacheData (cacheData: Record<string, any>): void {
+        writeFileSync(this.stateCacheFile, yaml.stringify(cacheData));
+    }
+
+    private availableCaches (cacheData: Record<string, any>): void {
+        const cacheNames = Object.keys(cacheData);
+        if (cacheNames.length > 0) {
+            this.log("Available caches:");
+            cacheNames.forEach((name) => this.log(`- ${name}`));
+        } else {
+            this.log("No cache available.");
+        }
+    }
+
+    private hash (data: string): string {
+        const sha256Hash = createHash("sha256");
+        sha256Hash.update(data);
+        return sha256Hash.digest("hex");
+    }
+
+    private getDockerFile (): Buffer {
+        const dockerComposeFilePath = join(this.chsDevConfig.projectPath, "docker-compose.yaml");
+        return yaml.parse(readFileSync(dockerComposeFilePath).toString("utf-8"));
+    }
+
+    private async handlePrompt (cacheName: string, action: "add" | "remove" | "wipe"): Promise<boolean> {
+        const messages: Record<string, string> = {
+            add: `This will save the cache or overwrite it if it already exists. Proceed?`,
+            remove: `Do you want to delete the cache named ${cacheName}?`,
+            wipe: "Do you want to delete all saved caches?"
+        };
+        return await confirm(messages[action]);
+    }
 }

--- a/src/commands/state/cache.ts
+++ b/src/commands/state/cache.ts
@@ -1,0 +1,49 @@
+import { Args, Command, Config, Flags } from "@oclif/core";
+import { StateManager } from "../../state/state-manager.js";
+import ChsDevConfig from "../../model/Config.js";
+import loadConfig from "../../helpers/config-loader.js";
+import { DockerCompose } from "../../run/docker-compose.js";
+import { confirm } from "../../helpers/user-input.js";
+
+export default class Cache extends Command {
+
+    static description = "Cache the state of chs-dev into a saved file";
+
+    static args = {
+        name: Args.string({
+            required: false,
+            description: "Name of the cache"
+        })
+    };
+
+    private readonly stateManager: StateManager;
+    private readonly chsDevConfig: ChsDevConfig;
+    private readonly dockerCompose: DockerCompose;
+
+    constructor (argv: string[], config: Config) {
+        super(argv, config);
+
+        const logger = {
+            log: (msg: string) => this.log(msg)
+        };
+        this.chsDevConfig = loadConfig();
+        this.stateManager = new StateManager(this.chsDevConfig.projectPath);
+        this.dockerCompose = new DockerCompose(this.chsDevConfig, logger);
+
+    }
+
+    async run (): Promise<any> {
+        const { args, flags } = await this.parse(Cache);
+        const timestamp: string = new Date(Date.now()).toISOString();
+        const cacheName: string = args.name || timestamp;
+
+        const handlePrompt = async (): Promise<boolean> => {
+            return await confirm(`save chs-dev state?`);
+        };
+
+        if (await handlePrompt()) {
+            //
+        }
+    }
+
+}

--- a/src/commands/state/clean.ts
+++ b/src/commands/state/clean.ts
@@ -33,13 +33,16 @@ export default class Clean extends Command {
         };
 
         if (await handlePrompt()) {
+            const containerStatus = this.dockerCompose.getServiceStatuses();
+            if (containerStatus !== undefined) {
+                this.error("Ensure all containers are stopped. Run: '$ chs-dev down'");
+            }
             this.stateManager.cleanState();
 
             await this.config.runHook("generate-runnable-docker-compose", {
                 generateExclusionSpec: false
             });
 
-            // Run docker purne volumes;
             this.dockerCompose.prune("volume");
 
         }

--- a/src/commands/state/clean.ts
+++ b/src/commands/state/clean.ts
@@ -1,0 +1,48 @@
+import { Command, Config, Flags } from "@oclif/core";
+import { StateManager } from "../../state/state-manager.js";
+import ChsDevConfig from "../../model/Config.js";
+import loadConfig from "../../helpers/config-loader.js";
+import { DockerCompose } from "../../run/docker-compose.js";
+import { confirm } from "../../helpers/user-input.js";
+
+export default class Clean extends Command {
+
+    static description = "Wipes the state of chs-dev and revert to a default state";
+
+    private readonly stateManager: StateManager;
+    private readonly chsDevConfig: ChsDevConfig;
+    private readonly dockerCompose: DockerCompose;
+
+    constructor (argv: string[], config: Config) {
+        super(argv, config);
+
+        const logger = {
+            log: (msg: string) => this.log(msg)
+        };
+        this.chsDevConfig = loadConfig();
+        this.stateManager = new StateManager(this.chsDevConfig.projectPath);
+        this.dockerCompose = new DockerCompose(this.chsDevConfig, logger);
+
+    }
+
+    async run (): Promise<any> {
+        await this.parse(Clean);
+
+        const handlePrompt = async (): Promise<boolean> => {
+            return await confirm(`This will reset your chs-dev state and delete all unused docker volumes. Do you want to proceed?`);
+        };
+
+        if (await handlePrompt()) {
+            this.stateManager.cleanState();
+
+            await this.config.runHook("generate-runnable-docker-compose", {
+                generateExclusionSpec: false
+            });
+
+            // Run docker purne volumes;
+            this.dockerCompose.prune("volume");
+
+        }
+    }
+
+}

--- a/src/commands/state/clean.ts
+++ b/src/commands/state/clean.ts
@@ -9,6 +9,14 @@ export default class Clean extends Command {
 
     static description = "Wipes the state of chs-dev and revert to a default state";
 
+    static flags = {
+        purge: Flags.boolean({
+            char: "p",
+            description: "Wipe state, volumes and images",
+            default: false
+        })
+    };
+
     private readonly stateManager: StateManager;
     private readonly chsDevConfig: ChsDevConfig;
     private readonly dockerCompose: DockerCompose;
@@ -26,10 +34,10 @@ export default class Clean extends Command {
     }
 
     async run (): Promise<any> {
-        await this.parse(Clean);
+        const { flags: { purge } } = await this.parse(Clean);
 
         const handlePrompt = async (): Promise<boolean> => {
-            return await confirm(`This will reset your chs-dev state and delete all unused docker volumes. Do you want to proceed?`);
+            return await confirm(`This will reset your chs-dev state and delete all unused docker volumes${purge ? " including images." : "."} Do you want to proceed?`);
         };
 
         if (await handlePrompt()) {
@@ -44,6 +52,9 @@ export default class Clean extends Command {
             });
 
             this.dockerCompose.prune("volume");
+            if (purge) {
+                this.dockerCompose.prune("image");
+            }
 
         }
     }

--- a/src/commands/state/clean.ts
+++ b/src/commands/state/clean.ts
@@ -47,9 +47,7 @@ export default class Clean extends Command {
             }
             this.stateManager.cleanState();
 
-            await this.config.runHook("generate-runnable-docker-compose", {
-                generateExclusionSpec: false
-            });
+            await this.config.runHook("generate-runnable-docker-compose", {});
 
             this.dockerCompose.prune("volume");
             if (purge) {

--- a/src/commands/state/export.ts
+++ b/src/commands/state/export.ts
@@ -1,0 +1,101 @@
+import { Args, Command, Config } from "@oclif/core";
+import { createHash } from "crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import yaml from "yaml";
+import loadConfig from "../../helpers/config-loader.js";
+import { confirm } from "../../helpers/user-input.js";
+import ChsDevConfig from "../../model/Config.js";
+import { StateManager } from "../../state/state-manager.js";
+
+type StateCache = {
+    state: {
+        snapshot: Record<string, any>;
+        hash: string
+    }
+    dockerCompose: {
+        snapshot: Record<string, any>;
+        hash: string;
+    }
+};
+const EXPORT_STATE_DIR = ".exported_state_cache";
+
+export default class Export extends Command {
+    static description = "Export current state of chs-dev into a saved file";
+
+    static args = {
+        name: Args.string({
+            required: true,
+            description: "Name of the exported file"
+        })
+    };
+
+    private readonly stateManager: StateManager;
+    private readonly chsDevConfig: ChsDevConfig;
+    private readonly exportedStateDir: string;
+
+    constructor (argv: string[], config: Config) {
+        super(argv, config);
+
+        this.chsDevConfig = loadConfig();
+        this.exportedStateDir = join(this.chsDevConfig.projectPath, EXPORT_STATE_DIR);
+
+        if (!existsSync(this.exportedStateDir)) {
+            mkdirSync(this.exportedStateDir, { recursive: true });
+        }
+
+        this.stateManager = new StateManager(this.chsDevConfig.projectPath);
+    }
+
+    async run (): Promise<void> {
+        const { args: { name } } = await this.parse(Export);
+
+        if (await confirm(`Export current state of chs-dev into a saved file: ${name}?`)) {
+            this.exportState(name);
+        }
+
+    }
+
+    private exportState (exportFileName: string): void {
+        const exportedFilename = join(this.exportedStateDir, `${exportFileName}.yaml`);
+
+        const exportData = [
+            "# DO NOT MODIFY MANUALLY",
+            yaml.stringify(this.getExportData())
+        ];
+
+        writeFileSync(exportedFilename, exportData.join("\n\n"));
+        this.log(`Exported state destination: ${exportedFilename}`);
+    }
+
+    private getExportData (): StateCache {
+        const stateSnapshot = this.stateManager.snapshot;
+        const dockerComposeSnapshot = this.getDockerFile();
+        return {
+            state: {
+                hash: this.hash(yaml.stringify(stateSnapshot)),
+                snapshot: stateSnapshot
+            },
+            dockerCompose: {
+                hash: this.hash(yaml.stringify(dockerComposeSnapshot)),
+                snapshot: dockerComposeSnapshot
+            }
+        };
+
+    }
+
+    private getDockerFile (): Buffer {
+        const dockerComposeFilePath = join(
+            this.chsDevConfig.projectPath,
+            "docker-compose.yaml"
+        );
+        return yaml.parse(readFileSync(dockerComposeFilePath).toString("utf-8"));
+    }
+
+    private hash (data: string): string {
+        const sha256Hash = createHash("sha256");
+        sha256Hash.update(data);
+        return sha256Hash.digest("hex");
+    }
+
+}

--- a/src/commands/state/restore.ts
+++ b/src/commands/state/restore.ts
@@ -1,0 +1,159 @@
+import { Args, Command, Config, Flags } from "@oclif/core";
+import { StateManager } from "../../state/state-manager.js";
+import ChsDevConfig from "../../model/Config.js";
+import loadConfig from "../../helpers/config-loader.js";
+import { DockerCompose } from "../../run/docker-compose.js";
+import { confirm } from "../../helpers/user-input.js";
+import { createHash } from "crypto";
+import yaml from "yaml";
+import { basename, join } from "path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+
+type StateCache = {
+    state: {
+        snapshot: Record<string, any>;
+        hash: string
+    }
+    dockerCompose: {
+        snapshot: Record<string, any>;
+        hash: string;
+    }
+};
+
+export default class Restore extends Command {
+    static description = "Restore and update the state files from saved cache or imported cache.";
+
+    static args = {
+        name: Args.string({
+            required: false,
+            description: "Name of the cache"
+        })
+    };
+
+    static flags = {
+        importCacheFrom: Flags.string({
+            char: "i",
+            description: "Path to the exported cache"
+        })
+    };
+
+    private readonly chsDevConfig: ChsDevConfig;
+    private readonly dockerCompose: DockerCompose;
+    private readonly stateCacheFile: string;
+
+    constructor (argv: string[], config: Config) {
+        super(argv, config);
+
+        this.chsDevConfig = loadConfig();
+        const cacheDir = config.cacheDir;
+        this.stateCacheFile = join(cacheDir, `${basename(this.chsDevConfig.projectName)}.state.yaml`);
+
+        const logger = { log: (msg: string) => this.log(msg) };
+
+        this.dockerCompose = new DockerCompose(this.chsDevConfig, logger);
+    }
+
+    async run (): Promise<void> {
+        const { args, flags: { importCacheFrom } } = await this.parse(Restore);
+
+        const containerStatus = this.dockerCompose.getServiceStatuses();
+        if (containerStatus !== undefined) {
+            this.error("Ensure all containers are stopped. Run: '$ chs-dev down'");
+        }
+
+        const cacheName = importCacheFrom ? "import-cache" : args.name;
+
+        if (!cacheName || typeof cacheName === "undefined") {
+            this.error("Please provide a valid cache name or use the --importCacheFrom or -i flag to restore from an imported cache.");
+        }
+
+        if (importCacheFrom) {
+            if (await this.handlePrompt(cacheName)) {
+                this.restoreFromImport(importCacheFrom);
+            }
+        } else {
+            if (await this.handlePrompt(cacheName)) {
+                this.restoreFromSavedCache(cacheName);
+            }
+        }
+
+    }
+
+    private restoreFromSavedCache (cacheName: string): void {
+        const cacheData = this.loadSavedCacheData();
+        const namedCacheData = cacheData[cacheName];
+        if (!namedCacheData) {
+            this.error(`Cache with name '${cacheName}' not found.`);
+        }
+        const data = this.verifyCacheAuthencity(namedCacheData, (stateCache) => stateCache);
+
+        this.restoreState(data);
+        this.log(`Restored state from saved cache '${cacheName}'`);
+    }
+
+    private restoreFromImport (importCache: string): void {
+        if (!existsSync(importCache)) {
+            this.error(`Import cache file does not exist in location: ${importCache}`);
+        }
+
+        const cacheData = this.parseYamlFile(importCache) as StateCache;
+
+        if (!cacheData || typeof cacheData !== "object") {
+            this.error(`Invalid cache data in imported file: ${importCache}`);
+        }
+
+        const data = this.verifyCacheAuthencity(cacheData, (stateCache) => stateCache);
+
+        this.restoreState(data);
+        this.log(`Restored state from imported cache.`);
+    }
+
+    private verifyCacheAuthencity<T> (cacheData: StateCache, cacheSupplier: (stateCache: StateCache) => StateCache): StateCache {
+
+        if (cacheData.state.hash === this.hash(yaml.stringify(cacheData.state.snapshot)) &&
+            cacheData.dockerCompose.hash === this.hash(yaml.stringify(cacheData.dockerCompose.snapshot))) {
+            return cacheSupplier(cacheData);
+        }
+        this.error("Cache data has been corrupted or touched.");
+    }
+
+    private restoreState ({ state, dockerCompose }: StateCache): void {
+        // Restore state file
+        const stateFilePath = join(this.chsDevConfig.projectPath, `.chs-dev.yaml`);
+        const stateData = [
+            "# DO NOT MODIFY MANUALLY",
+            yaml.stringify(state.snapshot)
+        ];
+        writeFileSync(stateFilePath, stateData.join("\n\n"));
+
+        // Restore docker-compose file
+        const dockerComposeFilePath = join(this.chsDevConfig.projectPath, "docker-compose.yaml");
+        const dockerComposeData = [
+            "# DO NOT MODIFY MANUALLY",
+            yaml.stringify(dockerCompose.snapshot)
+        ];
+        writeFileSync(dockerComposeFilePath, dockerComposeData.join("\n\n"));
+    }
+
+    private loadSavedCacheData (): Record<string, StateCache> {
+        if (existsSync(this.stateCacheFile)) {
+            return this.parseYamlFile(this.stateCacheFile) as Record<string, StateCache> || {};
+        }
+        return {};
+    }
+
+    private parseYamlFile (filePath: string): Record<string, StateCache> | StateCache {
+        return yaml.parse(readFileSync(filePath, "utf-8"));
+    }
+
+    private hash (data: string): string {
+        return createHash("sha256").update(data).digest("hex");
+    }
+
+    private async handlePrompt (cacheName: string): Promise<boolean> {
+        const message = cacheName === "import-cache"
+            ? `Restore from an imported cache?`
+            : `Restore from a saved cache '${cacheName}'?`;
+        return confirm(message);
+    }
+}

--- a/src/commands/state/restore.ts
+++ b/src/commands/state/restore.ts
@@ -1,5 +1,4 @@
 import { Args, Command, Config, Flags } from "@oclif/core";
-import { StateManager } from "../../state/state-manager.js";
 import ChsDevConfig from "../../model/Config.js";
 import loadConfig from "../../helpers/config-loader.js";
 import { DockerCompose } from "../../run/docker-compose.js";
@@ -66,7 +65,7 @@ export default class Restore extends Command {
         if (!cacheName || typeof cacheName === "undefined") {
             this.error("Please provide a valid cache name or use the --importCacheFrom or -i flag to restore from an imported cache.");
         }
-
+        console.log(`Restoring state from cache: ${cacheName}`);
         if (importCacheFrom) {
             if (await this.handlePrompt(cacheName)) {
                 this.restoreFromImport(importCacheFrom);

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -149,19 +149,18 @@ export class DockerCompose {
         );
     }
 
-    prune (commandArg: Prune, signal?: AbortSignal): void {
-        const logMsg = execSync(`docker ${commandArg} prune -f`, { encoding: "utf-8" });
-        // Log-: Total reclaimed space:
-        const watch = new LogEverythingLogHandler(this.logger).handle(logMsg);
-        // return this.runDockerCommands(
-        //     [
-        //         commandArg,
-        //         "prune",
-        //         "-f"
-        //     ],
-        //     new LogEverythingLogHandler(this.logger),
-        //     signal
-        // );
+    prune (commandArg: Prune): void {
+        try {
+            let logMsg: string;
+            if (commandArg === "volume") {
+                logMsg = execSync(`docker volume rm $(docker volume ls -qf dangling=true)`, { encoding: "utf-8" });
+            } else {
+                logMsg = execSync(`docker ${commandArg} prune -f`, { encoding: "utf-8" });
+            }
+            const log = new LogNothingLogHandler(logMsg, this.logger);
+        } catch (error) {
+            throw new Error(`Docker prune command failed: ${error}`);
+        }
     }
 
     private createStatusMatchLogHandler (pattern: RegExp, colouriser?: (status: string) => string) {

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -153,6 +153,10 @@ export class DockerCompose {
         try {
             let logMsg: string;
             if (commandArg === "volume") {
+                const volumes = execSync(`docker volume ls -qf dangling=true`, { encoding: "utf-8" });
+                if (volumes.length === 0) {
+                    return;
+                }
                 logMsg = execSync(`docker volume rm $(docker volume ls -qf dangling=true)`, { encoding: "utf-8" });
             } else {
                 logMsg = execSync(`docker ${commandArg} prune -f`, { encoding: "utf-8" });

--- a/src/state/state-manager.ts
+++ b/src/state/state-manager.ts
@@ -97,6 +97,15 @@ export class StateManager {
         }
     }
 
+    cleanState (): void {
+        this.dumpState({
+            modules: [],
+            services: [],
+            servicesWithLiveUpdate: [],
+            excludedServices: []
+        });
+    }
+
     private dumpState (state: State): void {
         const lines = [
             "# DO NOT MODIFY MANUALLY",

--- a/test/commands/state/cache.spec.ts
+++ b/test/commands/state/cache.spec.ts
@@ -80,7 +80,7 @@ describe("Cache Command", () => {
             }
         });
 
-        const handleActionSpy = jest.spyOn(cache as any, "handleAction").mockResolvedValue(undefined);
+        const handleActionSpy = jest.spyOn(cache as any, "handleActionWithPrompt").mockResolvedValue(undefined);
 
         await cache.run();
 
@@ -107,7 +107,7 @@ describe("Cache Command", () => {
                 remove: true
             }
         });
-        const handleActionSpy = jest.spyOn(cache as any, "handleAction").mockResolvedValue(undefined);
+        const handleActionSpy = jest.spyOn(cache as any, "handleActionWithPrompt").mockResolvedValue(undefined);
 
         await cache.run();
 
@@ -150,29 +150,29 @@ describe("Cache Command", () => {
             args: { name: "mycache" },
             flags: {}
         });
-        const handleActionSpy = jest.spyOn(cache as any, "handleAction").mockResolvedValue(undefined);
+        const handleActionSpy = jest.spyOn(cache as any, "handleActionWithPrompt").mockResolvedValue(undefined);
 
         await cache.run();
 
         expect(handleActionSpy).toHaveBeenCalledWith("mycache", "add", "Saved cache as 'mycache'");
     });
 
-    it("handleAction calls cacheActions and logs on confirm", async () => {
+    it("handleActionWithPrompt calls cacheActions and logs on confirm", async () => {
         const cacheActionsSpy = jest.spyOn(cache as any, "cacheActions").mockImplementation(() => {});
         const logSpy = jest.spyOn(cache, "log").mockImplementation(() => {});
         jest.spyOn(cache as any, "handlePrompt").mockResolvedValue(true);
 
-        await (cache as any).handleAction("mycache", "add", "Saved cache as 'mycache'");
+        await (cache as any).handleActionWithPrompt("mycache", "add", "Saved cache as 'mycache'");
 
         expect(cacheActionsSpy).toHaveBeenCalledWith("mycache", "add");
         expect(logSpy).toHaveBeenCalledWith("Saved cache as 'mycache'");
     });
 
-    it("handleAction does not call cacheActions if prompt is false", async () => {
+    it("handleActionWithPrompt does not call cacheActions if prompt is false", async () => {
         const cacheActionsSpy = jest.spyOn(cache as any, "cacheActions").mockImplementation(() => {});
         jest.spyOn(cache as any, "handlePrompt").mockResolvedValue(false);
 
-        await (cache as any).handleAction("mycache", "add", "Saved cache as 'mycache'");
+        await (cache as any).handleActionWithPrompt("mycache", "add", "Saved cache as 'mycache'");
 
         expect(cacheActionsSpy).not.toHaveBeenCalled();
     });
@@ -220,11 +220,11 @@ describe("Cache Command", () => {
         );
     });
 
-    it("exportCache throws error if cache does not exist", () => {
+    it("cacheByNameExists throws error if cache does not exist", () => {
 
         const errorSpy = jest.spyOn(cache, "error").mockImplementation((msg: any) => { throw new Error(msg); });
 
-        expect(() => (cache as any).exportCache({}, "bar")).toThrow("Cache named bar does not exist.");
+        expect(() => (cache as any).cacheByNameExists({}, "bar")).toThrow("Cache named bar does not exist.");
         errorSpy.mockRestore();
     });
 

--- a/test/commands/state/cache.spec.ts
+++ b/test/commands/state/cache.spec.ts
@@ -1,0 +1,235 @@
+import { expect, jest } from "@jest/globals";
+import Cache from "../../../src/commands/state/cache";
+import { StateManager } from "../../../src/state/state-manager";
+import { Config } from "@oclif/core";
+import State from "../../../src/model/State";
+import ChsDevConfig from "../../../src/model/Config";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import configLoaderMock from "../../../src/helpers/config-loader";
+import * as yaml from "yaml";
+import { join } from "path";
+
+jest.mock("fs");
+jest.mock("yaml");
+jest.mock("../../../src/state/state-manager");
+jest.mock("../../../src/helpers/config-loader");
+
+const chsDevConfig: ChsDevConfig = {
+    projectPath: "./docker-chs",
+    projectName: "docker-chs",
+    env: {},
+    versionSpecification: "<=0.1.16"
+};
+
+const stateSnapshot = {
+    modules: [],
+    services: [
+        "service-one"
+    ],
+    servicesWithLiveUpdate: [],
+    excludedServices: []
+};
+
+describe("Cache Command", () => {
+    let cache: Cache;
+    let testConfig: Config;
+
+    let parseMock: any;
+
+    const setUpCommand = (snapshot: State) => {
+
+        // @ts-expect-error
+        testConfig = { root: "./", configDir: "./config", cacheDir: "./cache" };
+
+        // @ts-expect-error
+        StateManager.mockReturnValue({ snapshot });
+
+        // @ts-expect-error
+        configLoaderMock.mockReturnValue(chsDevConfig);
+
+        cache = new Cache([], testConfig);
+
+        // @ts-expect-error
+        parseMock = jest.spyOn(cache, "parse");
+
+        parseMock.mockResolvedValue({
+            flags: {
+                wipe: false,
+                remove: false,
+                available: false,
+                exportCache: false
+            }
+        });
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        (existsSync as jest.Mock).mockReturnValue(true);
+        setUpCommand(stateSnapshot);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("handles --wipe flag", async () => {
+        parseMock.mockResolvedValue({
+            flags: {
+                wipe: true
+            }
+        });
+
+        const handleActionSpy = jest.spyOn(cache as any, "handleAction").mockResolvedValue(undefined);
+
+        await cache.run();
+
+        expect(handleActionSpy).toHaveBeenCalledWith("Wipe", "wipe", "Wiped all caches");
+    });
+
+    it("handles --available flag", async () => {
+        parseMock.mockResolvedValue({
+            flags: {
+                available: true
+            }
+        });
+        const cacheActionsSpy = jest.spyOn(cache as any, "cacheActions").mockImplementation(() => {});
+
+        await cache.run();
+
+        expect(cacheActionsSpy).toHaveBeenCalledWith("Available", "available");
+    });
+
+    it("handles --remove flag", async () => {
+        parseMock.mockResolvedValue({
+            args: { name: "testcache" },
+            flags: {
+                remove: true
+            }
+        });
+        const handleActionSpy = jest.spyOn(cache as any, "handleAction").mockResolvedValue(undefined);
+
+        await cache.run();
+
+        expect(handleActionSpy).toHaveBeenCalledWith("testcache", "remove", "Removed cache testcache");
+    });
+
+    it("handles --exportCache flag", async () => {
+        parseMock.mockResolvedValue({
+            args: { name: "testcache" },
+            flags: {
+                exportCache: true
+            }
+        });
+        const cacheActionsSpy = jest.spyOn(cache as any, "cacheActions").mockImplementation(() => {});
+
+        await cache.run();
+
+        expect(cacheActionsSpy).toHaveBeenCalledWith("testcache", "export");
+    });
+
+    it("requires cache name if not provided and not wipe/available", async () => {
+        parseMock.mockResolvedValue({
+            args: {},
+            flags: {
+                exportCache: true
+            }
+        });
+
+        const errorSpy = jest.spyOn(cache, "error").mockImplementation(
+            (msg: any) => {
+                throw new Error(msg);
+            });
+
+        await expect(cache.run()).rejects.toThrow("Cache name is required");
+        errorSpy.mockRestore();
+    });
+
+    it("adds a cache when no flags are set", async () => {
+        parseMock.mockResolvedValue({
+            args: { name: "mycache" },
+            flags: {}
+        });
+        const handleActionSpy = jest.spyOn(cache as any, "handleAction").mockResolvedValue(undefined);
+
+        await cache.run();
+
+        expect(handleActionSpy).toHaveBeenCalledWith("mycache", "add", "Saved cache as 'mycache'");
+    });
+
+    it("handleAction calls cacheActions and logs on confirm", async () => {
+        const cacheActionsSpy = jest.spyOn(cache as any, "cacheActions").mockImplementation(() => {});
+        const logSpy = jest.spyOn(cache, "log").mockImplementation(() => {});
+        jest.spyOn(cache as any, "handlePrompt").mockResolvedValue(true);
+
+        await (cache as any).handleAction("mycache", "add", "Saved cache as 'mycache'");
+
+        expect(cacheActionsSpy).toHaveBeenCalledWith("mycache", "add");
+        expect(logSpy).toHaveBeenCalledWith("Saved cache as 'mycache'");
+    });
+
+    it("handleAction does not call cacheActions if prompt is false", async () => {
+        const cacheActionsSpy = jest.spyOn(cache as any, "cacheActions").mockImplementation(() => {});
+        jest.spyOn(cache as any, "handlePrompt").mockResolvedValue(false);
+
+        await (cache as any).handleAction("mycache", "add", "Saved cache as 'mycache'");
+
+        expect(cacheActionsSpy).not.toHaveBeenCalled();
+    });
+
+    it("availableCaches logs available caches", () => {
+        const logSpy = jest.spyOn(cache, "log").mockImplementation(() => {});
+        (cache as any).availableCaches({ testcache: {}, mycache: {} });
+
+        expect(logSpy).toHaveBeenCalledWith("Available caches:");
+        expect(logSpy).toHaveBeenCalledWith("- testcache");
+        expect(logSpy).toHaveBeenCalledWith("- mycache");
+    });
+
+    it("availableCaches logs when no caches", () => {
+        const logSpy = jest.spyOn(cache, "log").mockImplementation(() => {});
+        (cache as any).availableCaches({});
+
+        expect(logSpy).toHaveBeenCalledWith("No cache available.");
+    });
+
+    it("exportCache writes file and logs", () => {
+
+        const logSpy = jest.spyOn(cache, "log").mockImplementation(() => {});
+        const cacheData = { foo: { some: "data" } };
+        const exportDir = join(chsDevConfig.projectPath, ".exported_state_cache");
+        const exportedFilename = join(exportDir, "foo.yaml");
+
+        (existsSync as jest.Mock).mockImplementation((p) => p === exportDir);
+        (mkdirSync as jest.Mock).mockImplementation(() => {});
+        (writeFileSync as jest.Mock).mockImplementation(() => {});
+
+        (cache as any).exportCache(cacheData, "foo");
+
+        const exportData = [
+            "# DO NOT MODIFY MANUALLY",
+            yaml.stringify(cacheData.foo)
+        ];
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            exportedFilename,
+            expect.stringMatching(exportData.join("\n\n"))
+        );
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining("Exported cache foo destination")
+        );
+    });
+
+    it("exportCache throws error if cache does not exist", () => {
+
+        const errorSpy = jest.spyOn(cache, "error").mockImplementation((msg: any) => { throw new Error(msg); });
+
+        expect(() => (cache as any).exportCache({}, "bar")).toThrow("Cache named bar does not exist.");
+        errorSpy.mockRestore();
+    });
+
+    it("hash returns sha256 hash", () => {
+        const hash = (cache as any).hash("hello");
+        expect(hash).toHaveLength(64);
+    });
+});

--- a/test/commands/state/clean.spec.ts
+++ b/test/commands/state/clean.spec.ts
@@ -113,7 +113,7 @@ describe("Clean Command", () => {
         await clean.run();
 
         expect(cleanStateMock).toHaveBeenCalled();
-        expect(runHookMock).toHaveBeenCalledWith("generate-runnable-docker-compose", { generateExclusionSpec: false });
+        expect(runHookMock).toHaveBeenCalledWith("generate-runnable-docker-compose", { });
         expect(dockerComposeMock.prune).toHaveBeenCalledWith("volume");
         expect(dockerComposeMock.prune).toHaveBeenCalledTimes(1);
     });

--- a/test/commands/state/clean.spec.ts
+++ b/test/commands/state/clean.spec.ts
@@ -1,0 +1,151 @@
+import { expect, jest } from "@jest/globals";
+import { Config } from "@oclif/core";
+import Clean from "../../../src/commands/state/clean";
+import configLoaderMock from "../../../src/helpers/config-loader";
+import { confirm as confirmMock } from "../../../src/helpers/user-input";
+import ChsDevConfig from "../../../src/model/Config";
+import State from "../../../src/model/State";
+import { DockerCompose } from "../../../src/run/docker-compose";
+import { StateManager } from "../../../src/state/state-manager";
+
+const dockerComposeMock = {
+    getServiceStatuses: jest.fn(),
+    prune: jest.fn()
+};
+const cleanStateMock = jest.fn();
+const runHookMock = jest.fn();
+
+jest.mock("../../../src/state/state-manager");
+jest.mock("../../../src/helpers/config-loader");
+jest.mock("../../../src/run/docker-compose");
+jest.mock("../../../src/helpers/user-input");
+
+const chsDevConfig: ChsDevConfig = {
+    projectPath: "./docker-chs",
+    projectName: "docker-chs",
+    env: {},
+    versionSpecification: "<=0.1.16"
+};
+
+const stateSnapshot = {
+    modules: [],
+    services: [
+        "service-one"
+    ],
+    servicesWithLiveUpdate: [],
+    excludedServices: []
+};
+
+describe("Clean Command", () => {
+    let clean: Clean;
+    let testConfig: Config;
+
+    let parseMock: any;
+
+    const setUpCommand = (snapshot: State) => {
+
+        // @ts-expect-error
+        testConfig = { root: "./", configDir: "./config", cacheDir: "./cache", runHook: runHookMock };
+
+        // @ts-expect-error
+        StateManager.mockReturnValue({ snapshot, cleanState: cleanStateMock });
+
+        // @ts-expect-error
+        configLoaderMock.mockReturnValue(chsDevConfig);
+
+        // @ts-expect-error
+        DockerCompose.mockReturnValue(dockerComposeMock);
+
+        clean = new Clean([], testConfig);
+
+        // @ts-expect-error
+        parseMock = jest.spyOn(clean, "parse");
+
+        parseMock.mockResolvedValue({
+            flags: {
+                purge: false
+            }
+        });
+
+        (confirmMock as jest.Mock).mockReturnValue(true);
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        setUpCommand(stateSnapshot);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("does nothing if user declines confirm prompt", async () => {
+        parseMock.mockResolvedValue({ flags: { purge: false } });
+        (confirmMock as jest.Mock).mockReturnValue(false);
+
+        await clean.run();
+
+        expect(cleanStateMock).not.toHaveBeenCalled();
+        expect(dockerComposeMock.prune).not.toHaveBeenCalled();
+        expect(runHookMock).not.toHaveBeenCalled();
+    });
+
+    it("throws error if containers are running", async () => {
+        parseMock.mockResolvedValue({ flags: { purge: false } });
+
+        dockerComposeMock.getServiceStatuses.mockReturnValue({ some: "status" });
+
+        const errorSpy = jest.spyOn(clean, "error").mockImplementation(() => { throw new Error("Containers running"); });
+
+        await expect(clean.run()).rejects.toThrow("Containers running");
+
+        expect(cleanStateMock).not.toHaveBeenCalled();
+        expect(dockerComposeMock.prune).not.toHaveBeenCalled();
+        expect(runHookMock).not.toHaveBeenCalled();
+    });
+
+    it("cleans state, runs hook, prunes volumes if containers are stopped", async () => {
+        parseMock.mockResolvedValue({ flags: { purge: false } });
+
+        dockerComposeMock.getServiceStatuses.mockReturnValue(undefined);
+
+        await clean.run();
+
+        expect(cleanStateMock).toHaveBeenCalled();
+        expect(runHookMock).toHaveBeenCalledWith("generate-runnable-docker-compose", { generateExclusionSpec: false });
+        expect(dockerComposeMock.prune).toHaveBeenCalledWith("volume");
+        expect(dockerComposeMock.prune).toHaveBeenCalledTimes(1);
+    });
+
+    it("prunes images if --purge flag is set", async () => {
+        parseMock.mockResolvedValue({ flags: { purge: true } });
+
+        dockerComposeMock.getServiceStatuses.mockReturnValue(undefined);
+
+        await clean.run();
+
+        expect(dockerComposeMock.prune).toHaveBeenCalledWith("volume");
+        expect(dockerComposeMock.prune).toHaveBeenCalledWith("image");
+        expect(dockerComposeMock.prune).toHaveBeenCalledTimes(2);
+    });
+
+    it("shows correct confirm prompt message for purge", async () => {
+        parseMock.mockResolvedValue({ flags: { purge: true } });
+        dockerComposeMock.getServiceStatuses.mockReturnValue(undefined);
+
+        await clean.run();
+
+        expect(confirmMock).toHaveBeenCalledWith(expect.stringContaining("including images"));
+    });
+
+    it("shows correct confirm prompt message for non-purge action", async () => {
+        parseMock.mockResolvedValue({ flags: { purge: false } });
+
+        dockerComposeMock.getServiceStatuses.mockReturnValue(undefined);
+
+        await clean.run();
+
+        expect(confirmMock).toHaveBeenCalledWith(expect.not.stringContaining("including images"));
+    });
+});

--- a/test/commands/state/export.spec.ts
+++ b/test/commands/state/export.spec.ts
@@ -1,0 +1,103 @@
+import { expect, jest } from "@jest/globals";
+import { Config } from "@oclif/core";
+import { existsSync } from "fs";
+import Export from "../../../src/commands/state/export";
+import configLoaderMock from "../../../src/helpers/config-loader";
+import { confirm as confirmMock } from "../../../src/helpers/user-input";
+import ChsDevConfig from "../../../src/model/Config";
+import State from "../../../src/model/State";
+import { StateManager } from "../../../src/state/state-manager";
+
+jest.mock("fs");
+jest.mock("yaml");
+jest.mock("../../../src/state/state-manager");
+jest.mock("../../../src/helpers/config-loader");
+jest.mock("../../../src/helpers/user-input");
+
+const chsDevConfig: ChsDevConfig = {
+    projectPath: "./docker-chs",
+    projectName: "docker-chs",
+    env: {},
+    versionSpecification: "<=0.1.16"
+};
+
+const stateSnapshot = {
+    modules: [],
+    services: [
+        "service-one"
+    ],
+    servicesWithLiveUpdate: [],
+    excludedServices: []
+};
+
+describe("Export state command", () => {
+    let exportState: Export;
+    let testConfig: Config;
+    let exportStateMock;
+
+    let parseMock: any;
+
+    const setUpCommand = (snapshot: State) => {
+
+        // @ts-expect-error
+        testConfig = { root: "./", configDir: "./config", cacheDir: "./cache" };
+
+        // @ts-expect-error
+        StateManager.mockReturnValue({ snapshot });
+
+        // @ts-expect-error
+        configLoaderMock.mockReturnValue(chsDevConfig);
+
+        exportState = new Export([], testConfig);
+
+        // @ts-expect-error
+        parseMock = jest.spyOn(exportState, "parse");
+
+        parseMock.mockResolvedValue({
+            args: {
+                name: "exportedState"
+            }
+        });
+        (confirmMock as jest.Mock).mockReturnValue(true);
+        exportStateMock = jest.spyOn(exportState as any, "exportState");
+        jest.spyOn(exportState as any, "getExportData").mockImplementation(() => {});
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        (existsSync as jest.Mock).mockReturnValue(true);
+        setUpCommand(stateSnapshot);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should call exportState if user confirms", async () => {
+        parseMock.mockResolvedValue({ args: { name: "testExport" } });
+
+        await exportState.run();
+
+        expect(exportStateMock).toHaveBeenCalledWith("testExport");
+    });
+
+    it("should not call exportState if user declines", async () => {
+        parseMock.mockResolvedValue({ args: { name: "testExport" } });
+        (confirmMock as jest.Mock).mockReturnValue(false);
+        await exportState.run();
+
+        expect(exportStateMock).not.toHaveBeenCalled();
+    });
+
+    it("should prompt with correct message", async () => {
+        parseMock.mockResolvedValue({ args: { name: "myExport" } });
+
+        await exportState.run();
+
+        expect(confirmMock).toHaveBeenCalledWith(
+            expect.stringContaining("Export current state of chs-dev into a saved file: myExport?")
+        );
+    });
+
+});

--- a/test/commands/state/restore.spec.ts
+++ b/test/commands/state/restore.spec.ts
@@ -1,0 +1,151 @@
+import { expect, jest } from "@jest/globals";
+import { Config } from "@oclif/core";
+import Restore from "../../../src/commands/state/restore";
+import configLoaderMock from "../../../src/helpers/config-loader";
+import { confirm as confirmMock } from "../../../src/helpers/user-input";
+import ChsDevConfig from "../../../src/model/Config";
+import { DockerCompose } from "../../../src/run/docker-compose";
+import { existsSync } from "fs";
+import * as yaml from "yaml";
+
+const dockerComposeMock = {
+    getServiceStatuses: jest.fn()
+};
+
+jest.mock("fs");
+jest.mock("yaml");
+jest.mock("../../../src/helpers/config-loader");
+jest.mock("../../../src/run/docker-compose");
+jest.mock("../../../src/helpers/user-input");
+
+const chsDevConfig: ChsDevConfig = {
+    projectPath: "./docker-chs",
+    projectName: "docker-chs",
+    env: {},
+    versionSpecification: "<=0.1.16"
+};
+
+describe("Restore Command", () => {
+    let restore: Restore;
+    let testConfig: Config;
+    let cacheData: any;
+    let stateCache: any;
+    let parseMock: any;
+
+    const setUpCommand = () => {
+
+        // @ts-expect-error
+        testConfig = { root: "./", configDir: "./config", cacheDir: "./cache" };
+
+        // @ts-expect-error
+        configLoaderMock.mockReturnValue(chsDevConfig);
+
+        // @ts-expect-error
+        DockerCompose.mockReturnValue(dockerComposeMock);
+
+        restore = new Restore([], testConfig);
+
+        // @ts-expect-error
+        parseMock = jest.spyOn(restore, "parse");
+
+        parseMock.mockResolvedValue({
+            args: { name: "cacheName" },
+            flags: {
+                importCacheFrom: false
+            }
+        });
+
+        (confirmMock as jest.Mock).mockReturnValue(true);
+
+        stateCache = {
+            state: {
+                snapshot: { foo: "bar" },
+                hash: jest.spyOn(restore as any, "hash").mockReturnValue(yaml.stringify({ foo: "bar" }))
+            },
+            dockerCompose: {
+                snapshot: { baz: "qux" },
+                hash: jest.spyOn(restore as any, "hash").mockReturnValue(yaml.stringify({ baz: "qux" }))
+            }
+        };
+        cacheData = { cacheName: stateCache };
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        (existsSync as jest.Mock).mockReturnValue(true);
+        setUpCommand();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("restoreFromSavedCache", () => {
+
+        it("should restore state from saved cache", () => {
+            jest.spyOn(restore as any, "loadSavedCacheData").mockReturnValue(cacheData);
+            const verifySpy = jest.spyOn(restore as any, "verifyCacheAuthencity").mockReturnValue(stateCache);
+            const restoreStateSpy = jest.spyOn(restore as any, "restoreState").mockImplementation(() => {});
+            const logSpy = jest.spyOn(restore, "log").mockImplementation(() => {});
+
+            (restore as any).restoreFromSavedCache("cacheName");
+
+            expect(verifySpy).toHaveBeenCalledWith(stateCache, expect.any(Function));
+            expect(restoreStateSpy).toHaveBeenCalledWith(stateCache);
+            expect(logSpy).toHaveBeenCalledWith("Restored state from saved cache 'cacheName'");
+        });
+
+        it("should error if cache not found", () => {
+            jest.spyOn(restore as any, "loadSavedCacheData").mockReturnValue({});
+            const errorSpy = jest.spyOn(restore, "error").mockImplementation(() => { throw new Error("err"); });
+
+            expect(() => (restore as any).restoreFromSavedCache("missing")).toThrow("err");
+            expect(errorSpy).toHaveBeenCalledWith("Cache with name 'missing' not found.");
+        });
+    });
+
+    describe("restoreFromImport", () => {
+
+        it("should restore state from imported cache", () => {
+            jest.spyOn(restore as any, "parseYamlFile").mockReturnValue(stateCache);
+            const verifySpy = jest.spyOn(restore as any, "verifyCacheAuthencity").mockReturnValue(stateCache);
+            const restoreStateSpy = jest.spyOn(restore as any, "restoreState").mockImplementation(() => {});
+            const logSpy = jest.spyOn(restore, "log").mockImplementation(() => {});
+
+            (restore as any).restoreFromImport("/import/path.yaml");
+
+            expect(verifySpy).toHaveBeenCalledWith(stateCache, expect.any(Function));
+            expect(restoreStateSpy).toHaveBeenCalledWith(stateCache);
+            expect(logSpy).toHaveBeenCalledWith("Restored state from imported cache.");
+        });
+
+        it("should error if import file does not exist", () => {
+            (existsSync as jest.Mock).mockReturnValue(false);
+            const errorSpy = jest.spyOn(restore, "error").mockImplementation(() => { throw new Error("err"); });
+            expect(() => (restore as any).restoreFromImport("/bad/path.yaml")).toThrow("err");
+            expect(errorSpy).toHaveBeenCalledWith("Import cache file does not exist in location: /bad/path.yaml");
+        });
+
+        it("should error if imported cache data is invalid", () => {
+            (existsSync as jest.Mock).mockReturnValue(true);
+            jest.spyOn(restore as any, "parseYamlFile").mockReturnValue(undefined);
+            const errorSpy = jest.spyOn(restore, "error").mockImplementation(() => { throw new Error("err"); });
+            expect(() => (restore as any).restoreFromImport("/import/path.yaml")).toThrow("err");
+            expect(errorSpy).toHaveBeenCalledWith("Invalid cache data in imported file: /import/path.yaml");
+        });
+    });
+
+    describe("verifyCacheAuthencity", () => {
+        it("should error if hashes do not match", () => {
+            const badCache = {
+                state: { snapshot: { foo: "bar" }, hash: "bad" },
+                dockerCompose: { snapshot: { baz: "qux" }, hash: "bad" }
+            };
+            const errorSpy = jest.spyOn(restore, "error").mockImplementation(() => { throw new Error("err"); });
+            expect(() => (restore as any).verifyCacheAuthencity(badCache, (c: any) => c)).toThrow("err");
+            expect(errorSpy).toHaveBeenCalledWith("Cache data has been corrupted or touched.");
+        });
+    });
+
+});


### PR DESCRIPTION


[Add state clean command](https://github.com/companieshouse/chs-dev/commit/85b0a88741d1bef68bddb9766097517f1f7975a2) 

- state clean command helps revert the chs-dev state to default by removing volumes, emptying the .chs-dev.yaml file object properties and reverting generated docker-compose.yaml to default state

[ensure all container are down before cleaning state](https://github.com/companieshouse/chs-dev/commit/fcc4863c25ac12e8ce33903a9406a0f16b3c10f4) 

- ensure all volumes named and anonymous are removed

[add flags to the cache state command](https://github.com/companieshouse/chs-dev/commit/16cdbd2a1855c7917f708e5ed6d0ec231d6fdd12) 

- add the wipe all, remove <cacheName>, add <cacheName>, list all saved cache feature

[feat(state): add export, restore, and cache management commands](https://github.com/companieshouse/chs-dev/commit/033025511101006d40e644db5b877409a984dc5e) 

- Implement `chs-dev state export <fileName>` to export the current chs-dev state to a file in the docker-chs-development directory.
-  Add `chs-dev state restore <savedCacheName>` and `chs-dev state restore --importCacheFrom=<filePath>` to support restoring from saved or external cache files.
- Add `chs-dev state cache <cacheName> --exportCache` for exporting named cache.
- Improve volume cleanup: ensure volume prune only runs when dangling volumes exist.
- Enhance `chs-dev state clean` with a `--purge` flag to remove both dangling and unused images.

[Add unit test cases to the state commands](https://github.com/companieshouse/chs-dev/commit/080058cfb3dcd66ce6ab143078c02d26ae09caa1)