### PR TITLE
CC-2547: Fix the reload behaviour for Repository Services - Chips

### DIFF
--- a/docs/troubleshooting-remedies/correctly-add-healthcheck-to-service-docker-compose.md
+++ b/docs/troubleshooting-remedies/correctly-add-healthcheck-to-service-docker-compose.md
@@ -31,8 +31,8 @@ healthcheck:
           "CMD-SHELL",
           "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/company-profile-api/healthcheck || exit 1",
         ]
-      timeout: 5s
-      retries: 3
+      retries: 6
+      start_period: 15s
 
 ```
 

--- a/docs/troubleshooting-remedies/correctly-node-services-for-development-mode.md
+++ b/docs/troubleshooting-remedies/correctly-node-services-for-development-mode.md
@@ -41,6 +41,20 @@ app.listen(PORT, () => {
 });
 
 ```
+
+```js
+const app = require("./../app");
+
+const PORT = 3000;
+
+app.set("port", PORT);
+
+app.listen(PORT, () => {
+  console.log(`:white_tick:  Application Ready. Running on port ${PORT}`);
+});
+
+```
+
 It is important the listen event is configured exactly as described above:
 This output is used to verify the application is up and running.
 Sample `nodemon.entry` file: `/local/builders/node/v3/bin/config/nodemon-entry`.

--- a/docs/troubleshooting-remedies/correctly-node-services-for-development-mode.md
+++ b/docs/troubleshooting-remedies/correctly-node-services-for-development-mode.md
@@ -50,7 +50,7 @@ const PORT = 3000;
 app.set("port", PORT);
 
 app.listen(PORT, () => {
-  console.log(`:white_tick:  Application Ready. Running on port ${PORT}`);
+  console.log(`✅  Application Ready. Running on port ${PORT}`);
 });
 
 ```

--- a/docs/troubleshooting-remedies/correctly-reload-repository-services-using-chs-dev.md
+++ b/docs/troubleshooting-remedies/correctly-reload-repository-services-using-chs-dev.md
@@ -4,7 +4,7 @@
 
 Repository services typically include:
 
-- Java (e.g., CHIPS)
+- Non-Standard Java (e.g., CHIPS)
 - Perl services
 - Go services
 

--- a/docs/troubleshooting-remedies/correctly-reload-repository-services-using-chs-dev.md
+++ b/docs/troubleshooting-remedies/correctly-reload-repository-services-using-chs-dev.md
@@ -1,0 +1,57 @@
+# Correctly Reload Respository Services Using CHS-DEV
+
+## Summary
+
+Repository services typically include:
+
+- Java (e.g., CHIPS)
+- Perl services
+- Go services
+
+Each of these has specific configuration or setup steps, which will be detailed individually below to help streamline your development process in chs-dev.
+
+
+## JAVA (CHIPS)
+
+Before starting the CHIPS service, ensure the healthcheck configuration is added to its `docker-compose.yaml` file as shown below:
+
+```yaml
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -o /dev/null -w '%{http_code}' http://localhost:7001/chips/rest/healthcheck || exit 1",
+        ]
+      retries: 6
+      start_period: 15s
+
+```
+Note: The retries and start_period settings are essential, as the CHIPS service typically has a longer startup time.
+
+### Reload Behaviour
+
+To reload the CHIPS service:
+
+1. From the terminal within the CHIPS project directory, run:
+
+```bash
+
+ant -f build/developers/build.xml cbd
+
+```
+This builds the CHIPS files.
+
+2. Then, execute:
+
+```bash
+
+chs-dev reload chips
+
+```
+
+3. For additional build information, refer to the [CHIPS documentation](https://github.com/companieshouse/docker-chs-development/blob/master/docs/chips.md).
+
+
+## PERL and GO
+
+Updates for Perl and Go-based services will be added soon.

--- a/src/commands/reload.ts
+++ b/src/commands/reload.ts
@@ -12,6 +12,7 @@ type ReloadFunc = (serviceName: string, flags: any) => Promise<void>
 
 const NODE_BUILDER = "node";
 const NGINX_BUILDER = "nginx";
+const REPOSITORY_BUILDER = "repository";
 const NO_CHANGES_PATTERN = /"?([\w-]+)"?\s+\|\s+.*No changes\./;
 
 /**
@@ -63,6 +64,7 @@ export default class Reload extends Command {
         this.reloadStrategies = new Map<string, ReloadFunc>([
             [NODE_BUILDER, this.reloadNodeService.bind(this)],
             [NGINX_BUILDER, this.reloadNginxService.bind(this)],
+            [REPOSITORY_BUILDER, this.reloadRepositoryService.bind(this)],
             ["default", this.reloadJavaService.bind(this)]
         ]);
     }
@@ -151,7 +153,7 @@ export default class Reload extends Command {
         this.dependencyCache.update();
         this.log(`Service: ${serviceName} building...`);
 
-        const noChangesFound = await this.dockerCompose.build(`${serviceName}-builder`, NO_CHANGES_PATTERN);
+        const noChangesFound = await this.dockerCompose.build(`${serviceName}-builder`, "builderContainer", NO_CHANGES_PATTERN);
         if (noChangesFound) {
             this.log(`No changes found in code. Terminating reload.`);
             this.log(`Use the --force flag (-f) to rebuild if necessary.`);
@@ -160,6 +162,19 @@ export default class Reload extends Command {
             await this.dockerCompose.restart(serviceName);
             this.dockerCompose.healthCheck([serviceName]);
         }
+    }
+
+    /**
+     * Reloads a Repository service by rebuilding the container.
+     * @param serviceName - Name of the service to reload
+     *  @param flags - Flags passed to the command
+     */
+    private async reloadRepositoryService (serviceName: string): Promise<void> {
+        this.dependencyCache.update();
+        this.log(`Service: ${serviceName} building...`);
+        const boss = await this.dockerCompose.build(`${serviceName}`, "nonBuilderContainer");
+        this.dockerCompose.healthCheck([serviceName]);
+
     }
 
     /**

--- a/src/commands/reload.ts
+++ b/src/commands/reload.ts
@@ -153,7 +153,7 @@ export default class Reload extends Command {
         }
         this.log(`Service: ${serviceName} building...`);
 
-        const noChangesFound = await this.dockerCompose.build(`${serviceName}-builder`, ContainerType.builder, NO_CHANGES_PATTERN);
+        const noChangesFound = await this.dockerCompose.build(`${serviceName}-builder`, ContainerType.BUILDER, NO_CHANGES_PATTERN);
         if (noChangesFound) {
             this.log(`No changes found in code. Terminating reload.`);
             this.log(`Use the --force flag (-f) to rebuild if necessary.`);
@@ -171,7 +171,7 @@ export default class Reload extends Command {
      */
     private async reloadRepositoryService (serviceName: string): Promise<void> {
         this.log(`Service: ${serviceName} building...`);
-        const boss = await this.dockerCompose.build(`${serviceName}`, ContainerType.application);
+        const boss = await this.dockerCompose.build(`${serviceName}`, ContainerType.APPLICATION);
         this.dockerCompose.healthCheck([serviceName]);
 
     }

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -251,7 +251,6 @@ export default class Up extends Command {
 
             this.handleHealthCheck(builderContext);
 
-            this.dependencyCache.update();
             const logsArgs = {
                 serviceNames: this.servicesInDevelopmentMode,
                 tail: "10",

--- a/src/generator/development/spec-assembly/index.ts
+++ b/src/generator/development/spec-assembly/index.ts
@@ -11,7 +11,6 @@ import { volumeSpecAssemblyFunction } from "./volume-spec-assembly-function.js";
 
 const specFieldsWhichAreMutable = [
     "build",
-    "develop",
     "env_file",
     "volumes",
     "depends_on",

--- a/src/hooks/check-development-service-config.ts
+++ b/src/hooks/check-development-service-config.ts
@@ -20,7 +20,7 @@ export const hook: Hook<"check-development-service-config"> = async ({ services,
     for (const service of services) {
         if (service.builder === "node") {
             checkNodeServiceConfig(service, projectPath, context);
-        } else if (service.builder.includes("java") || service.builder.includes("repository")) {
+        } else if (service.builder.includes("java") || service.builder.includes("repository") || !service.builder) {
             checkServiceHealthCheckConfig(service, context);
         }
     }

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,4 +1,4 @@
 export enum ContainerType {
-    builder,
-    application
+    BUILDER,
+    APPLICATION
 }

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,0 +1,4 @@
+export enum ContainerType {
+    builder,
+    application
+}

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -129,9 +129,9 @@ export class DockerCompose {
             : new LogNothingLogHandler(this.logFile, this.logger);
 
         let args: string[];
-        if (containerType === ContainerType.builder) {
+        if (containerType === ContainerType.BUILDER) {
             args = ["up", "--build", "--exit-code-from", serviceName, serviceName];
-        } else if (containerType === ContainerType.application) {
+        } else if (containerType === ContainerType.APPLICATION) {
             args = ["up", "--build", "--force-recreate", "--no-deps", "--detach", serviceName];
         } else {
             throw new Error(`Unknown container type: ${containerType}`);

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -9,6 +9,7 @@ import LogEverythingLogHandler from "./logs/LogEverythingLogHandler.js";
 import LogNothingLogHandler from "./logs/LogNothingLogHandler.js";
 import { LogHandler } from "./logs/logs-handler.js";
 import PatternMatchingConsoleLogHandler from "./logs/PatternMatchingConsoleLogHandler.js";
+import { ContainerType } from "../model/index.js";
 
 interface Logger {
     log: (msg: string) => void;
@@ -31,8 +32,6 @@ type LogsArgs = {
     follow: boolean | undefined,
     signal: AbortSignal | undefined
 }
-
-type ContainerType = "builderContainer" | "nonBuilderContainer"
 
 export class DockerCompose {
 
@@ -112,11 +111,12 @@ export class DockerCompose {
 
     /**
      * Builds a service using docker compose.
-     * Specifically useful for one-off tasks or builder containers
-     * @param serviceName - The name of the service to build.
-     * @param regxPattern - Optional regex pattern to match against logs.
+     * Useful for running one-off tasks/builder containers or long-running/application containers.
+     * @param serviceName - Name of the service to build.
+     * @param containerType - Type of container: "builder" or "application".
+     * @param regxPattern - Optional regex pattern to match log output.
      * @param signal - Optional AbortSignal to cancel the operation.
-     * @returns A promise that resolves to true if the pattern was matched, or void if no pattern was provided.
+     * @returns A promise that resolves to true if the pattern was matched in logs, or void if no pattern was provided.
      */
     async build (
         serviceName: string,
@@ -129,7 +129,7 @@ export class DockerCompose {
             : new LogNothingLogHandler(this.logFile, this.logger);
 
         const args =
-            containerType === "builderContainer"
+            containerType === ContainerType.builder
                 ? ["up", "--build", "--exit-code-from", serviceName, serviceName]
                 : ["up", "--build", "--force-recreate", "--no-deps", "--detach", serviceName];
 

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -128,10 +128,14 @@ export class DockerCompose {
             ? new PatternMatchingConsoleLogHandler(regxPattern, this.logFile, this.logger)
             : new LogNothingLogHandler(this.logFile, this.logger);
 
-        const args =
-            containerType === ContainerType.builder
-                ? ["up", "--build", "--exit-code-from", serviceName, serviceName]
-                : ["up", "--build", "--force-recreate", "--no-deps", "--detach", serviceName];
+        let args: string[];
+        if (containerType === ContainerType.builder) {
+            args = ["up", "--build", "--exit-code-from", serviceName, serviceName];
+        } else if (containerType === ContainerType.application) {
+            args = ["up", "--build", "--force-recreate", "--no-deps", "--detach", serviceName];
+        } else {
+            throw new Error(`Unknown container type: ${containerType}`);
+        }
 
         await this.runDockerCompose(args, logHandler, signal);
 

--- a/src/state/builders.ts
+++ b/src/state/builders.ts
@@ -82,14 +82,6 @@ const repositoryBuilderSpec = yaml.stringify({
                     // eslint-disable-next-line no-template-curly-in-string
                     SSH_PRIVATE_KEY_PASSPHRASE: "${SSH_PRIVATE_KEY_PASSPHRASE}"
                 }
-            },
-            develop: {
-                watch: [
-                    {
-                        path: ".touch",
-                        action: "rebuild"
-                    }
-                ]
             }
         }
     }

--- a/test/commands/reload.spec.ts
+++ b/test/commands/reload.spec.ts
@@ -5,8 +5,7 @@ import { join } from "path";
 import { Config } from "@oclif/core";
 import Reload from "../../src/commands/reload";
 import { DockerCompose } from "../../src/run/docker-compose";
-
-const updateDependencyCacheMock = jest.fn();
+import { ContainerType } from "../../src/model";
 
 const loadConfigMock = jest.fn();
 
@@ -44,14 +43,6 @@ jest.mock("../../src/state/inventory", () => {
             return {
                 services
             };
-        }
-    };
-});
-
-jest.mock("../../src/run/dependency-cache", () => {
-    return {
-        DependencyCache: function () {
-            return { update: updateDependencyCacheMock };
         }
     };
 });
@@ -162,16 +153,14 @@ describe("reload spec", () => {
         });
 
         jest.spyOn(reload as any, "checkServicesBuilder").mockReturnValue("java");
-        const updateMock = jest.spyOn(reload["dependencyCache"], "update");
         const buildMock = jest.spyOn(reload["dockerCompose"], "build");
         const restartMock = jest.spyOn(reload["dockerCompose"], "restart");
         const healthCheckMock = jest.spyOn(reload["dockerCompose"], "healthCheck");
 
         await reload.run();
 
-        expect(updateMock).toHaveBeenCalled();
         expect(logMock).toHaveBeenCalledWith("Service: service-one building...");
-        expect(buildMock).toHaveBeenCalledWith("service-one-builder", "builderContainer", NO_CHANGES_PATTERN);
+        expect(buildMock).toHaveBeenCalledWith("service-one-builder", ContainerType.builder, NO_CHANGES_PATTERN);
         expect(logMock).toHaveBeenCalledWith("Service: service-one restarting...");
         expect(restartMock).toHaveBeenCalledWith("service-one");
         expect(healthCheckMock).toHaveBeenCalledWith(["service-one"]);
@@ -189,7 +178,6 @@ describe("reload spec", () => {
         });
 
         jest.spyOn(reload as any, "checkServicesBuilder").mockReturnValue("java");
-        const updateMock = jest.spyOn(reload["dependencyCache"], "update");
         const buildMock = jest.spyOn(reload["dockerCompose"], "build").mockResolvedValueOnce(true);
 
         const restartMock = jest.spyOn(reload["dockerCompose"], "restart");
@@ -197,9 +185,8 @@ describe("reload spec", () => {
 
         await reload.run();
 
-        expect(updateMock).toHaveBeenCalled();
         expect(logMock).toHaveBeenCalledWith("Service: service-two building...");
-        expect(buildMock).toHaveBeenCalledWith("service-two-builder", "builderContainer", NO_CHANGES_PATTERN);
+        expect(buildMock).toHaveBeenCalledWith("service-two-builder", ContainerType.builder, NO_CHANGES_PATTERN);
         expect(logMock).toHaveBeenCalledWith("No changes found in code. Terminating reload.");
         expect(logMock).toHaveBeenCalledWith("Use the --force flag (-f) to rebuild if necessary.");
     });
@@ -236,14 +223,12 @@ describe("reload spec", () => {
         });
 
         jest.spyOn(reload as any, "checkServicesBuilder").mockReturnValue("repository");
-        const updateMock = jest.spyOn(reload["dependencyCache"], "update");
         const buildMock = jest.spyOn(reload["dockerCompose"], "build");
         const healthCheckMock = jest.spyOn(reload["dockerCompose"], "healthCheck");
 
         await reload.run();
 
-        expect(updateMock).toHaveBeenCalled();
-        expect(buildMock).toHaveBeenCalledWith("service-one", "nonBuilderContainer");
+        expect(buildMock).toHaveBeenCalledWith("service-one", ContainerType.application);
         expect(logMock).toHaveBeenCalledWith("Service: service-one building...");
         expect(healthCheckMock).toHaveBeenCalledWith(["service-one"]);
     });

--- a/test/commands/reload.spec.ts
+++ b/test/commands/reload.spec.ts
@@ -160,7 +160,7 @@ describe("reload spec", () => {
         await reload.run();
 
         expect(logMock).toHaveBeenCalledWith("Service: service-one building...");
-        expect(buildMock).toHaveBeenCalledWith("service-one-builder", ContainerType.builder, NO_CHANGES_PATTERN);
+        expect(buildMock).toHaveBeenCalledWith("service-one-builder", ContainerType.BUILDER, NO_CHANGES_PATTERN);
         expect(logMock).toHaveBeenCalledWith("Service: service-one restarting...");
         expect(restartMock).toHaveBeenCalledWith("service-one");
         expect(healthCheckMock).toHaveBeenCalledWith(["service-one"]);
@@ -186,7 +186,7 @@ describe("reload spec", () => {
         await reload.run();
 
         expect(logMock).toHaveBeenCalledWith("Service: service-two building...");
-        expect(buildMock).toHaveBeenCalledWith("service-two-builder", ContainerType.builder, NO_CHANGES_PATTERN);
+        expect(buildMock).toHaveBeenCalledWith("service-two-builder", ContainerType.BUILDER, NO_CHANGES_PATTERN);
         expect(logMock).toHaveBeenCalledWith("No changes found in code. Terminating reload.");
         expect(logMock).toHaveBeenCalledWith("Use the --force flag (-f) to rebuild if necessary.");
     });
@@ -228,7 +228,7 @@ describe("reload spec", () => {
 
         await reload.run();
 
-        expect(buildMock).toHaveBeenCalledWith("service-one", ContainerType.application);
+        expect(buildMock).toHaveBeenCalledWith("service-one", ContainerType.APPLICATION);
         expect(logMock).toHaveBeenCalledWith("Service: service-one building...");
         expect(healthCheckMock).toHaveBeenCalledWith(["service-one"]);
     });

--- a/test/commands/up.spec.ts
+++ b/test/commands/up.spec.ts
@@ -5,14 +5,12 @@ import { State } from "../../src/model/State";
 import { services, modules } from "../utils/data";
 import { StateManager } from "../../src/state/state-manager";
 import { Inventory } from "../../src/state/inventory";
-import { DependencyCache } from "../../src/run/dependency-cache";
 import { DockerCompose } from "../../src/run/docker-compose";
 import { DevelopmentMode } from "../../src/run/development-mode";
 import { ComposeLogViewer } from "../../src/run/compose-log-viewer";
 import { PermanentRepositories } from "../../src/state/permanent-repositories";
 import { OtelGenerator } from "../../src/generator/otel-generator";
 
-const dependencyCacheUpdateMock = jest.fn();
 const composeLogViewerViewMock = jest.fn();
 const permanentRepositoriesEnsureAllExistAndAreUpToDateMock = jest.fn();
 
@@ -101,11 +99,6 @@ describe("Up command", () => {
         StateManager.mockReturnValue({ snapshot });
 
         // @ts-expect-error
-        DependencyCache.mockReturnValue({
-            update: dependencyCacheUpdateMock
-        });
-
-        // @ts-expect-error
         DockerCompose.mockReturnValue(dockerComposeMock);
 
         // @ts-expect-error
@@ -180,12 +173,6 @@ describe("Up command", () => {
         await up.run();
 
         expect(developmentModeMock.start).not.toHaveBeenCalled();
-    });
-
-    it("should not update dependency cache when no services in dev mode", async () => {
-        await up.run();
-
-        expect(dependencyCacheUpdateMock).not.toHaveBeenCalled();
     });
 
     it("should display a couple of lines of output if it fails", async () => {
@@ -273,12 +260,6 @@ describe("Up command", () => {
             await up.run();
 
             expect(dockerComposeMock.healthCheck).toHaveBeenCalled();
-        });
-
-        it("should update dependency cache", async () => {
-            await up.run();
-
-            expect(dependencyCacheUpdateMock).toHaveBeenCalled();
         });
 
         it("should display a couple of lines of output if it fails", async () => {

--- a/test/generator/development/__snapshots__/development-docker-compose-factory.spec.ts.snap
+++ b/test/generator/development/__snapshots__/development-docker-compose-factory.spec.ts.snap
@@ -59,14 +59,6 @@ exports[`DevelopmentDockerComposeSpecFactory create adds builder service 1`] = `
       "context": "/home/test-user/projects/docker-chs",
       "dockerfile": "locals/builder/java/v2/build.Dockerfile",
     },
-    "develop": {
-      "watch": [
-        {
-          "action": "rebuild",
-          "path": ".touch",
-        },
-      ],
-    },
     "volumes": [
       "repositories/service-seven:/app/",
       "./out:/opt/out",

--- a/test/generator/development/spec-assembly/__snapshots__/builder-spec-assembly-function.spec.ts.snap
+++ b/test/generator/development/spec-assembly/__snapshots__/builder-spec-assembly-function.spec.ts.snap
@@ -25,14 +25,6 @@ exports[`builderSpecAssemblyFunction adds dependency builder on service and can 
       "context": "/home/test/user/projects/docker-project",
       "dockerfile": "local/builders/java/v2/build.Dockerfile",
     },
-    "develop": {
-      "watch": [
-        {
-          "action": "rebuild",
-          "path": ".touch",
-        },
-      ],
-    },
     "volumes": [
       "repositories/service-four:/app/",
       "./out:/opt/out",
@@ -62,14 +54,6 @@ exports[`builderSpecAssemblyFunction adds dependency builder on service and can 
     "build": {
       "context": "/home/test/user/projects/docker-project",
       "dockerfile": "local/builders/java/v2/build.Dockerfile",
-    },
-    "develop": {
-      "watch": [
-        {
-          "action": "rebuild",
-          "path": ".touch",
-        },
-      ],
     },
     "volumes": [
       "repositories/service-four:/app/",
@@ -101,14 +85,6 @@ exports[`builderSpecAssemblyFunction adds extra builder service to the generated
       "context": "/home/test/user/projects/docker-project",
       "dockerfile": "local/builders/java/v2/build.Dockerfile",
     },
-    "develop": {
-      "watch": [
-        {
-          "action": "rebuild",
-          "path": ".touch",
-        },
-      ],
-    },
     "volumes": [
       "repositories/service-four:/app/",
       "./out:/opt/out",
@@ -138,14 +114,6 @@ exports[`builderSpecAssemblyFunction applies extra properties to service 1`] = `
     "build": {
       "context": "/home/test/user/projects/docker-project",
       "dockerfile": "local/builders/java/v2/build.Dockerfile",
-    },
-    "develop": {
-      "watch": [
-        {
-          "action": "rebuild",
-          "path": ".touch",
-        },
-      ],
     },
     "volumes": [
       "repositories/service-four:/app/",
@@ -214,14 +182,6 @@ exports[`builderSpecAssemblyFunction can handle using builder and service docker
     "context": "/home/test/user/projects/docker-project",
     "dockerfile": "local/builders/java/v2/build.Dockerfile",
   },
-  "develop": {
-    "watch": [
-      {
-        "action": "rebuild",
-        "path": ".touch",
-      },
-    ],
-  },
   "volumes": [
     "repositories/service-one:/app/",
     "./out:/opt/out",
@@ -252,14 +212,6 @@ exports[`builderSpecAssemblyFunction can handle using builder and service docker
   "build": {
     "context": "/home/test/user/projects/docker-project",
     "dockerfile": "local/builders/java/v2/build.Dockerfile",
-  },
-  "develop": {
-    "watch": [
-      {
-        "action": "rebuild",
-        "path": ".touch",
-      },
-    ],
   },
   "volumes": [
     "repositories/service-one:/app/",

--- a/test/generator/development/spec-assembly/immutable-service-fields-spec-assembly-function.spec.ts
+++ b/test/generator/development/spec-assembly/immutable-service-fields-spec-assembly-function.spec.ts
@@ -18,7 +18,6 @@ describe("immutableServiceFieldsSpecAssemblyFunction", () => {
 
         const mutableFields = [
             "build",
-            "develop",
             "env_file",
             "volumes",
             "depends_on",

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -429,9 +429,9 @@ describe("DockerCompose", () => {
 
         });
 
-        it("runs docker compose build", async () => {
+        it("runs docker compose build for builder containers", async () => {
 
-            await dockerCompose.build(serviceName);
+            await dockerCompose.build(serviceName, "builderContainer");
 
             const expectedSpawnOptions = {
                 logHandler: { handle: mockWatchLogHandle },
@@ -453,6 +453,35 @@ describe("DockerCompose", () => {
                 "--build",
                 "--exit-code-from",
                 serviceName,
+                serviceName
+            ], expect.anything());
+        });
+
+        it("runs docker compose build for Non-builder containers", async () => {
+
+            await dockerCompose.build(serviceName, "nonBuilderContainer");
+
+            const expectedSpawnOptions = {
+                logHandler: { handle: mockWatchLogHandle },
+                spawnOptions: {
+                    cwd: config.projectPath,
+                    env: {
+                        ...(process.env),
+                        SSH_PRIVATE_KEY: sshPrivateKey,
+                        ANOTHER_VALUE: "another-value",
+                        ...mockAwsCredentialsObject
+                    }
+                },
+                acceptableExitCodes: [0, 130]
+            };
+
+            expect(spawnMock).toHaveBeenCalledWith("docker", [
+                "compose",
+                "up",
+                "--build",
+                "--force-recreate",
+                "--no-deps",
+                "--detach",
                 serviceName
             ], expect.anything());
         });

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -4,13 +4,13 @@ import fs, { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import Config from "../../src/model/Config";
+import { ContainerType } from "../../src/model";
 
 describe("DockerCompose", () => {
     const execSyncMock = jest.spyOn(childProcess, "execSync");
     const spawnMock = jest.fn();
     const existsSyncMock = jest.spyOn(fs, "existsSync");
     const mkdirSyncMock = jest.spyOn(fs, "mkdirSync");
-    const readFileSyncMock = jest.spyOn(fs, "readFileSync");
 
     const mockPatternMatchingHandle = jest.fn();
     const mockWatchLogHandle = jest.fn();
@@ -431,7 +431,7 @@ describe("DockerCompose", () => {
 
         it("runs docker compose build for builder containers", async () => {
 
-            await dockerCompose.build(serviceName, "builderContainer");
+            await dockerCompose.build(serviceName, ContainerType.builder);
 
             const expectedSpawnOptions = {
                 logHandler: { handle: mockWatchLogHandle },
@@ -459,7 +459,7 @@ describe("DockerCompose", () => {
 
         it("runs docker compose build for Non-builder containers", async () => {
 
-            await dockerCompose.build(serviceName, "nonBuilderContainer");
+            await dockerCompose.build(serviceName, ContainerType.application);
 
             const expectedSpawnOptions = {
                 logHandler: { handle: mockWatchLogHandle },
@@ -484,6 +484,10 @@ describe("DockerCompose", () => {
                 "--detach",
                 serviceName
             ], expect.anything());
+        });
+
+        it("docker compose build should throw an error if the container type is invalid ", async () => {
+            await expect(dockerCompose.build(serviceName, "unknown" as any)).rejects.toThrowError("Unknown container type: unknown");
         });
 
         it("rejects when code is not 0 or 130", async () => {

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -431,7 +431,7 @@ describe("DockerCompose", () => {
 
         it("runs docker compose build for builder containers", async () => {
 
-            await dockerCompose.build(serviceName, ContainerType.builder);
+            await dockerCompose.build(serviceName, ContainerType.BUILDER);
 
             const expectedSpawnOptions = {
                 logHandler: { handle: mockWatchLogHandle },
@@ -459,7 +459,7 @@ describe("DockerCompose", () => {
 
         it("runs docker compose build for Non-builder containers", async () => {
 
-            await dockerCompose.build(serviceName, ContainerType.application);
+            await dockerCompose.build(serviceName, ContainerType.APPLICATION);
 
             const expectedSpawnOptions = {
                 logHandler: { handle: mockWatchLogHandle },

--- a/test/state/builders.spec.ts
+++ b/test/state/builders.spec.ts
@@ -138,14 +138,6 @@ describe("getBuilder", () => {
                             // eslint-disable-next-line no-template-curly-in-string
                             SSH_PRIVATE_KEY_PASSPHRASE: "${SSH_PRIVATE_KEY_PASSPHRASE}"
                         }
-                    },
-                    develop: {
-                        watch: [
-                            {
-                                path: ".touch",
-                                action: "rebuild"
-                            }
-                        ]
                     }
                 }
             }
@@ -183,14 +175,6 @@ describe("getBuilder", () => {
                                 // eslint-disable-next-line no-template-curly-in-string
                                 SSH_PRIVATE_KEY_PASSPHRASE: "${SSH_PRIVATE_KEY_PASSPHRASE}"
                             }
-                        },
-                        develop: {
-                            watch: [
-                                {
-                                    path: ".touch",
-                                    action: "rebuild"
-                                }
-                            ]
                         }
                     }
                 }

--- a/test/utils/docker-compose-spec.ts
+++ b/test/utils/docker-compose-spec.ts
@@ -59,15 +59,7 @@ export const generateBuilderSpec = (builderPath: string, separateBuilder: boolea
             volumes: [
                 "<repository_path>:/app/",
                 "./out:/opt/out"
-            ],
-            develop: {
-                watch: [
-                    {
-                        path: ".touch",
-                        action: "rebuild"
-                    }
-                ]
-            }
+            ]
         };
     }
 
@@ -139,9 +131,6 @@ export const createCompleteServiceSpecForServiceWithName = (serviceName: string)
                 "service-5"
             ],
             deploy: {},
-            develop: {
-                watch: "my-file"
-            },
             device_cgroup_rules: [
                 "c 1:3 mr"
             ],


### PR DESCRIPTION
[Fix the reload behaviour for repository services - CHIPs](https://github.com/companieshouse/chs-dev/commit/20a9f10ce8386ae49491a13af49ac7e3b42c3114) 

- add new functionality for the reload behaviour for CHIPs with documentation.
- clean up on `up` module codebase. Rename functions and break codes into functions for better readability.
- ensure the DevelopmentStart method is only called to watch logs for Node and Nginx application. Other Builder services do not need to keep the terminal running. This enable user to execute the reload command on same terminal session.
- enhance the docker-compose module build functionality to build both builder containers(start and stop) and long running/regular containers.
- remove the develop/watch properties from docker-compose.yaml configurations and  test case snapshots
- update test cases
- update documentations