### PR TITLE
INO-11: Feature -> Reduce number of services by excluding service and its dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,13 @@ Adds a new service to the exclusions list
 
 ```
 USAGE
-  $ chs-dev exclude SERVICE...
+  $ chs-dev exclude SERVICE... [-d]
 
 ARGUMENTS
   SERVICE...  name of service being excluded from the docker environment
+
+FLAGS
+  -d, --dependency  Add services dependencies to the exclusion list.
 
 DESCRIPTION
   Adds a new service to the exclusions list
@@ -328,10 +331,13 @@ Adds a new service to the exclusions list
 
 ```
 USAGE
-  $ chs-dev exclusions add SERVICE...
+  $ chs-dev exclusions add SERVICE... [-d]
 
 ARGUMENTS
   SERVICE...  name of service being excluded from the docker environment
+
+FLAGS
+  -d, --dependency  Add services dependencies to the exclusion list.
 
 DESCRIPTION
   Adds a new service to the exclusions list
@@ -361,10 +367,13 @@ Removes an exclusion for a service.
 
 ```
 USAGE
-  $ chs-dev exclusions remove SERVICE...
+  $ chs-dev exclusions remove SERVICE... [-d]
 
 ARGUMENTS
   SERVICE...  name of service being reincluded in the docker environment
+
+FLAGS
+  -d, --dependency  Remove service and its dependencies from the exclusion list.
 
 DESCRIPTION
   Removes an exclusion for a service.
@@ -399,10 +408,13 @@ Removes an exclusion for a service.
 
 ```
 USAGE
-  $ chs-dev include SERVICE...
+  $ chs-dev include SERVICE... [-d]
 
 ARGUMENTS
   SERVICE...  name of service being reincluded in the docker environment
+
+FLAGS
+  -d, --dependency  Remove service and its dependencies from the exclusion list.
 
 DESCRIPTION
   Removes an exclusion for a service.

--- a/src/commands/AbstractStateModificationCommand.ts
+++ b/src/commands/AbstractStateModificationCommand.ts
@@ -39,6 +39,7 @@ export default abstract class AbstractStateModificationCommand extends Command {
 
     protected readonly inventory: Inventory;
     protected readonly stateManager: StateManager;
+    protected readonly serviceLoader: ServiceLoader;
 
     protected argumentValidationPredicate: ArgumentValidationPredicate = defaultValidationPredicate;
     protected validArgumentHandler: ValidArgumentHandler = defaultValidArgumentHandler;
@@ -55,6 +56,7 @@ export default abstract class AbstractStateModificationCommand extends Command {
         this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
         this.stateManager = new StateManager(this.chsDevConfig.projectPath);
         this.stateModificationObjectType = stateModificationObjectType;
+        this.serviceLoader = new ServiceLoader(this.inventory);
     }
 
     async run (): Promise<any> {

--- a/src/commands/exclusions/add.ts
+++ b/src/commands/exclusions/add.ts
@@ -1,11 +1,14 @@
-import { Args, Config } from "@oclif/core";
+import { Args, Config, Flags } from "@oclif/core";
 import AbstractStateModificationCommand from "../AbstractStateModificationCommand.js";
 import { serviceValidator } from "../../helpers/validator.js";
+import { ServiceLoader } from "../../run/service-loader.js";
+import { read, readFileSync } from "fs";
+import { join } from "path";
+import yaml from "yaml";
+import { DockerComposeSpec } from "../../model/DockerComposeSpec.js";
 
 export default class Add extends AbstractStateModificationCommand {
-
     static description = "Adds a new service to the exclusions list";
-
     static aliases = ["exclude"];
 
     static args = {
@@ -16,24 +19,106 @@ export default class Add extends AbstractStateModificationCommand {
         })
     };
 
+    static flags = {
+        dependency: Flags.boolean({
+            name: "dependency",
+            char: "d",
+            aliases: ["dependency"],
+            default: false,
+            description: "Add services dependencies to the exclusion list."
+        })
+    };
+
     constructor (argv: string[], config: Config) {
         super(argv, config, "service");
-
         this.preHookCheckWarnings = this.handlePreHookCheck;
-
         this.argumentValidationPredicate = serviceValidator(this.inventory, this.error);
         this.validArgumentHandler = this.handleValidService;
     }
 
-    private async handlePreHookCheck (commandArgv: string[]): Promise<string|undefined> {
+    protected override parseArgumentsAndFlags (): Promise<{
+        argv: unknown[],
+        flags: Record<string, any>
+    }> {
+        return this.parse(Add);
+    }
+
+    private async handlePreHookCheck (commandArgv: string[]): Promise<string | undefined> {
         return await this.handleServiceModuleStateHook({ topic: "exclusions", commandArgv });
     }
 
-    private handleValidService (serviceName: string): Promise<void> {
+    private async handleValidService (serviceName: string): Promise<void> {
+        const dependency = this.flagValues?.dependency || false;
+        const logs: string[] = [];
+
+        if (dependency) {
+            logs.push(...await this.handleDependencyExclusion(serviceName));
+        }
+
+        logs.push(this.excludeAndLog(serviceName));
+        logs.forEach(msg => this.log(msg));
+    }
+
+    private async handleDependencyExclusion (serviceName: string): Promise<string[]> {
+        const logs: string[] = [];
+        const dependencies = this.inventory.getServiceDirectDependencies(serviceName);
+
+        if (dependencies.length > 0) {
+            logs.push(`Adding "${serviceName}" and its dependencies to the exclusion list`);
+            const alreadyDependent: string[] = [];
+
+            for (const dep of dependencies) {
+                if (this.isDependentServiceADependentInAnotherService(serviceName, dep, alreadyDependent)) {
+                    continue;
+                }
+                logs.push(this.excludeAndLog(dep));
+            }
+
+            if (alreadyDependent.length > 0) {
+                logs.push(...alreadyDependent);
+            }
+        } else {
+            logs.push(`No dependencies found for service "${serviceName}"`);
+        }
+        return logs;
+    }
+
+    private isDependentServiceADependentInAnotherService (
+        parentServiceName: string,
+        dependentServiceName: string,
+        alreadyDependent: string[]
+    ): boolean {
+        const serviceLoader = new ServiceLoader(this.inventory);
+        const enabledServiceNames = serviceLoader
+            .loadServicesNames(this.stateManager.snapshot)
+            .filter(name => !this.stateManager.snapshot.excludedServices.includes(name));
+
+        for (const enabledService of enabledServiceNames) {
+            if (
+                enabledService === parentServiceName ||
+                enabledService === dependentServiceName
+            ) {
+                continue;
+            }
+
+            try {
+                if (this.inventory.getServiceDirectDependencies(enabledService).includes(dependentServiceName)) {
+                    alreadyDependent.push(this.handleDependencyMessages(enabledService, dependentServiceName));
+                    return true;
+                }
+            } catch (err) {
+                alreadyDependent.push(`Failed to parse docker compose for service "${enabledService}": ${err}`);
+            }
+        }
+        return false;
+    }
+
+    private excludeAndLog (serviceName: string): string {
         this.stateManager.addExclusionForService(serviceName);
+        return `Service "${serviceName}" is excluded`;
+    }
 
-        this.log(`Service "${serviceName}" is excluded`);
-
-        return Promise.resolve();
+    private handleDependencyMessages (serviceName: string, dependentService: string): string {
+        return `Service "${dependentService}" is also a dependent service of "${serviceName}" and cannot be excluded`;
     }
 }

--- a/src/commands/exclusions/remove.ts
+++ b/src/commands/exclusions/remove.ts
@@ -48,18 +48,18 @@ export default class Remove extends AbstractStateModificationCommand {
             logs.push(...await this.handleDependencyExclusion(serviceName));
         }
 
-        logs.push(this.excludeAndLog(serviceName));
+        logs.push(this.handleExcludeAndLog(serviceName));
         logs.forEach(msg => this.log(msg));
     }
 
     private async handleDependencyExclusion (serviceName: string): Promise<string[]> {
         const logs: string[] = [];
-        const dependencies = this.inventory.getServiceDirectDependencies(serviceName);
+        const dependencies = this.serviceLoader.getServiceDirectDependencies(serviceName);
 
         if (dependencies.length > 0) {
             logs.push(`Removing"${serviceName}" and its dependencies from the exclusion list`);
             for (const dep of dependencies) {
-                logs.push(this.excludeAndLog(dep));
+                logs.push(this.handleExcludeAndLog(dep));
             }
 
         } else {
@@ -68,7 +68,7 @@ export default class Remove extends AbstractStateModificationCommand {
         return logs;
     }
 
-    private excludeAndLog (serviceName: string): string {
+    private handleExcludeAndLog (serviceName: string): string {
         this.stateManager.removeExclusionForService(serviceName);
         return `Service "${serviceName}" is included (previous exclusion removed)`;
     }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -118,23 +118,26 @@ export default class Status extends Command {
         serviceState: (serviceName: string, colourise: boolean) => string,
         enabledServiceNames: string[]
     ) {
+        const { modules, services, excludedServices } = state;
         this.log("Manually activated modules:");
-        for (const module of state.modules) {
+        for (const module of modules) {
             this.log(` - ${module}`);
         }
 
         this.log("\nManually activated services:");
-        for (const service of state.services) {
+        for (const service of services) {
             this.log(` - ${service} ${serviceState(service, true)}`);
         }
 
         this.log("\nAutomatically activated services:");
+        enabledServiceNames = enabledServiceNames.filter(serviceName => !excludedServices.includes(serviceName));
+
         for (const serviceName of enabledServiceNames) {
             this.log(` - ${serviceName} ${serviceState(serviceName, true)} ${state.servicesWithLiveUpdate.includes(serviceName) ? "[LIVE UPDATE]" : ""}`);
         }
 
         this.log("\nManually deactivated services:");
-        for (const file of state.excludedServices || []) {
+        for (const file of excludedServices || []) {
             this.log(` - ${file}`);
         }
     }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -137,7 +137,7 @@ export default class Status extends Command {
         }
 
         this.log("\nManually deactivated services:");
-        for (const file of excludedServices || []) {
+        for (const file of excludedServices.sort() || []) {
             this.log(` - ${file}`);
         }
     }

--- a/src/state/inventory.ts
+++ b/src/state/inventory.ts
@@ -9,7 +9,6 @@ import { Service } from "../model/Service.js";
 import { Module } from "../model/Module.js";
 import { readServices } from "./service-reader.js";
 import { DependencyNameResolver } from "./dependency-name-resolver.js";
-import { DockerComposeSpec } from "../model/DockerComposeSpec.js";
 
 interface InventoryCache {
   hash: string;
@@ -38,28 +37,6 @@ export class Inventory {
 
     get services (): Service[] {
         return this.getFromCache(inventoryCache => inventoryCache.services);
-    }
-
-    getServiceDependencies (serviceName: string): string[] {
-        return this.getFromCache(inventoryCache => {
-            const service = inventoryCache.services.find(s => s.name === serviceName);
-            if (typeof service !== "undefined") {
-                return service.dependsOn as string[];
-            }
-            return [];
-        });
-    }
-
-    getServiceDirectDependencies (serviceName: string): string[] {
-        const service = this.getFromCache(inventoryCache =>
-            inventoryCache.services.find(s => s.name === serviceName)
-        );
-        if (!service?.source) return [];
-        const dockerCompose: DockerComposeSpec = yaml.parse(
-            readFileSync(service.source, "utf-8")
-        );
-        const dependsOn = dockerCompose.services?.[serviceName]?.depends_on || [];
-        return Array.isArray(dependsOn) ? dependsOn : Object.keys(dependsOn);
     }
 
     private getFromCache<T> (cacheSupplier: (inventoryCache: InventoryCache) => T): T {
@@ -112,7 +89,7 @@ export class Inventory {
 
         this.serviceFiles
             .map(serviceFile => readFileSync(serviceFile))
-            .forEach(serviceFile => {
+            .forEach((serviceFile:any) => {
                 sha256Hash.update(serviceFile);
             });
 

--- a/test/commands/__snapshots__/status.spec.ts.snap
+++ b/test/commands/__snapshots__/status.spec.ts.snap
@@ -91,7 +91,7 @@ Manually activated services:",
     " - service-eight ([32mUp About an hour[39m)",
   ],
   [
-    " - service-three ([32m[1mUp About an hour (healthy)[22m[39m)",
+    " - service-three ([90mNot running[39m)",
   ],
   [
     "
@@ -120,9 +120,6 @@ Automatically activated services:",
   ],
   [
     " - service-six ([31mExited (137)[39m) ",
-  ],
-  [
-    " - service-three ([32m[1mUp About an hour (healthy)[22m[39m) ",
   ],
   [
     " - service-two ([32m[1mUp 2 minutes (healthy)[22m[39m) [LIVE UPDATE]",
@@ -171,7 +168,7 @@ Manually activated services:",
     " - service-eight ([32mUp About an hour[39m)",
   ],
   [
-    " - service-three ([32m[1mUp About an hour (healthy)[22m[39m)",
+    " - service-three ([90mNot running[39m)",
   ],
   [
     "
@@ -194,9 +191,6 @@ Automatically activated services:",
   ],
   [
     " - service-six ([31mExited (137)[39m) ",
-  ],
-  [
-    " - service-three ([32m[1mUp About an hour (healthy)[22m[39m) ",
   ],
   [
     " - service-two ([32m[1mUp 2 minutes (healthy)[22m[39m) [LIVE UPDATE]",
@@ -265,9 +259,6 @@ Automatically activated services:",
   ],
   [
     " - service-six  ",
-  ],
-  [
-    " - service-three  ",
   ],
   [
     " - service-two  [LIVE UPDATE]",

--- a/test/commands/status.spec.ts
+++ b/test/commands/status.spec.ts
@@ -117,7 +117,6 @@ describe("Status command", () => {
             "service-five": "Exited (0)",
             "service-six": "Exited (137)",
             "service-seven": "Up 33 minutes",
-            "service-three": "Up About an hour (healthy)",
             "service-eight": "Up About an hour"
         });
 
@@ -135,7 +134,6 @@ describe("Status command", () => {
             "service-five": "Exited (0)",
             "service-six": "Exited (137)",
             "service-seven": "Up 33 minutes",
-            "service-three": "Up About an hour (healthy)",
             "service-eight": "Up About an hour",
             "otel-collector": "Up About an hour",
             loki: "Up About an hour",


### PR DESCRIPTION
Modify the exclusion command feature of the chs-dev cli to allow exclusion of services and their dependencies from the list of automatically enabled services. 

**Usage:**
`chs-dev exclusion add <service-name> --dependency` 
The --dependency (or -d) flag tells chs-dev to also exclude all direct dependencies of the specified service—greatly reducing the startup load.


**Commit:**
[Include dependencies when excluding services](https://github.com/companieshouse/chs-dev/commit/d01a9ab053538cf14a870d2f7f05b38cb98a5cbb) 

- use the flag feature '-d' to exclude a service dependencies