### PR TITLE
INO-11: Feature -> Add Dependency Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ USAGE
 
 <!-- commands -->
 * [`chs-dev autocomplete [SHELL]`](#chs-dev-autocomplete-shell)
+* [`chs-dev dependency service SERVICES`](#chs-dev-dependency-service-services)
+* [`chs-dev dependency system`](#chs-dev-dependency-system)
 * [`chs-dev development disable SERVICES`](#chs-dev-development-disable-services)
 * [`chs-dev development enable SERVICES`](#chs-dev-development-enable-services)
 * [`chs-dev development services`](#chs-dev-development-services)
@@ -231,6 +233,36 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v3.1.11/src/commands/autocomplete/index.ts)_
+
+## `chs-dev dependency service SERVICES`
+
+Generates a dependency diagram / tree for the specified service(s)
+
+```
+USAGE
+  $ chs-dev dependency service SERVICES... -t <value>
+
+ARGUMENTS
+  SERVICES...  names of services to be graphed
+
+FLAGS
+  -t, --type=<value>  (required) diagram / tree / flattree
+
+DESCRIPTION
+  Generates a dependency diagram / tree for the specified service(s)
+```
+
+## `chs-dev dependency system`
+
+Generates a System dependency Diagram
+
+```
+USAGE
+  $ chs-dev dependency system
+
+DESCRIPTION
+  Generates a System dependency Diagram
+```
 
 ## `chs-dev development disable SERVICES`
 
@@ -629,7 +661,7 @@ USAGE
   $ chs-dev state export NAME
 
 ARGUMENTS
-  NAME  Specify the export file name using letters, numbers, and optional underscores.
+  NAME  Specify the export file name using letters, numbers, and optional underscores or hypens.
 
 DESCRIPTION
   Export the current state of chs-dev as a named file into the 'exported_state_cache' directory. This is useful when you
@@ -756,10 +788,6 @@ EXAMPLES
 
   $ chs-dev up --no-otel
 ```
-
-DOCUMENTATION
-OpenTelemetry is a framework for collecting and exporting traces, metrics, and logs to observe services in chs-dev. When enabled, service logs and metrics can be processed and viewed in the [Grafana interface](http://api.chs.local/grafana).
-[Link to the Opentelemetry documentation](https://companieshouse.atlassian.net/wiki/spaces/TP/pages/5369659489/OpenTelemetry+Instrumenting+Services+with+docker-chs-development)
 <!-- commandsstop -->
 
 ## chs-dev Configuration

--- a/README.md
+++ b/README.md
@@ -788,6 +788,10 @@ EXAMPLES
 
   $ chs-dev up --no-otel
 ```
+
+DOCUMENTATION
+OpenTelemetry is a framework for collecting and exporting traces, metrics, and logs to observe services in chs-dev. When enabled, service logs and metrics can be processed and viewed in the [Grafana interface](http://api.chs.local/grafana).
+[Link to the Opentelemetry documentation](https://companieshouse.atlassian.net/wiki/spaces/TP/pages/5369659489/OpenTelemetry+Instrumenting+Services+with+docker-chs-development)
 <!-- commandsstop -->
 
 ## chs-dev Configuration

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ USAGE
 
 <!-- commands -->
 * [`chs-dev autocomplete [SHELL]`](#chs-dev-autocomplete-shell)
-* [`chs-dev dependency service SERVICES`](#chs-dev-dependency-service-services)
+* [`chs-dev dependency service SERVICE`](#chs-dev-dependency-service-service)
 * [`chs-dev dependency system`](#chs-dev-dependency-system)
 * [`chs-dev development disable SERVICES`](#chs-dev-development-disable-services)
 * [`chs-dev development enable SERVICES`](#chs-dev-development-enable-services)
@@ -234,22 +234,23 @@ EXAMPLES
 
 _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v3.1.11/src/commands/autocomplete/index.ts)_
 
-## `chs-dev dependency service SERVICES`
+## `chs-dev dependency service SERVICE`
 
-Generates a dependency diagram / tree for the specified service(s)
+Generates a dependency diagram / tree for the specified service
 
 ```
 USAGE
-  $ chs-dev dependency service SERVICES... -t <value>
+  $ chs-dev dependency service SERVICE... -t diagram|tree|flattree
 
 ARGUMENTS
-  SERVICES...  names of services to be graphed
+  SERVICE...  names of service to be graphed
 
 FLAGS
-  -t, --type=<value>  (required) diagram / tree / flattree
+  -t, --type=<option>  (required) diagram / tree / flattree
+                       <options: diagram|tree|flattree>
 
 DESCRIPTION
-  Generates a dependency diagram / tree for the specified service(s)
+  Generates a dependency diagram / tree for the specified service
 ```
 
 ## `chs-dev dependency system`

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@types/semver": "^7.3.1",
         "ansis": "^3.3.2",
         "glob": "^7.1.6",
+        "node-graphviz": "^0.1.1",
+        "open": "^10.2.0",
         "semver": "^7.3.2",
         "simple-git": "^3.22.0",
         "supports-hyperlinks": "^3.1.0",
@@ -6155,6 +6157,21 @@
         "semver": "^7.0.0"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -6933,6 +6950,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -6969,6 +7014,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -9239,6 +9296,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -11165,6 +11255,12 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/node-graphviz": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/node-graphviz/-/node-graphviz-0.1.1.tgz",
+      "integrity": "sha512-riY8/pFGSD1ipmyzqCwuN2M6W02ELfuLDjhJvTrQCUS/15tyU8ExkC96mlQrNLBK8Ws0z8PdH+ChBT6DuPFWWA==",
+      "license": "MIT"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -13888,6 +13984,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -14820,6 +14934,18 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -16351,6 +16477,36 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@types/semver": "^7.3.1",
     "ansis": "^3.3.2",
     "glob": "^7.1.6",
+    "node-graphviz": "^0.1.1",
+    "open": "^10.2.0",
     "semver": "^7.3.2",
     "simple-git": "^3.22.0",
     "supports-hyperlinks": "^3.1.0",
@@ -103,6 +105,9 @@
       },
       "troubleshoot": {
         "description": "analyses and outputs state of the system for troubleshooting and support"
+      },
+      "dependency": {
+        "description": "generates the dependency information of a service or system"
       }
     }
   },

--- a/src/commands/AbstractStateModificationCommand.ts
+++ b/src/commands/AbstractStateModificationCommand.ts
@@ -23,6 +23,9 @@ type HookResult = {
     failures: Failure[];
     successes: Success[];
 };
+
+type StateModificationObjectType = "service" | "module";
+type DependencyObjectType = "service" | "system";
 type ArgumentValidationPredicate = (argument: string) => boolean;
 type ValidArgumentHandler = (argument: string) => Promise<void>;
 type PreHookCheck = (argument: string[]) => Promise<string | undefined>;
@@ -31,11 +34,13 @@ const defaultValidationPredicate = (_: string) => true;
 const defaultValidArgumentHandler = (_: string) => Promise.reject(new Error("Command not configured correctly"));
 const defaultPrehookCheck = async (argument: string[]) => Promise.resolve(undefined);
 
-export default abstract class AbstractStateModificationCommand extends Command {
+export default abstract class AbstractStateModificationCommand <
+  T extends StateModificationObjectType | DependencyObjectType = StateModificationObjectType
+> extends Command {
 
     static strict = false;
 
-    private readonly stateModificationObjectType: "service" | "module";
+    private readonly stateModificationObjectType: T;
 
     protected readonly inventory: Inventory;
     protected readonly stateManager: StateManager;
@@ -48,7 +53,7 @@ export default abstract class AbstractStateModificationCommand extends Command {
 
     protected flagValues: Record<string, any> | undefined = undefined;
 
-    constructor (argv: string[], config: Config, stateModificationObjectType: "service" | "module") {
+    constructor (argv: string[], config: Config, stateModificationObjectType: T) {
         super(argv, config);
 
         this.chsDevConfig = loadConfig();

--- a/src/commands/AbstractStateModificationCommand.ts
+++ b/src/commands/AbstractStateModificationCommand.ts
@@ -5,6 +5,7 @@ import ChsDevConfig from "../model/Config.js";
 import loadConfig from "../helpers/config-loader.js";
 import { ServiceLoader } from "../run/service-loader.js";
 import { Plugin } from "@oclif/core/lib/interfaces/plugin.js";
+import { DependencyObjectType } from "../model/DependencyGraph.js";
 
 type ServiceModuleStateHook = {
     topic: string
@@ -25,7 +26,6 @@ type HookResult = {
 };
 
 type StateModificationObjectType = "service" | "module";
-type DependencyObjectType = "service" | "system";
 type ArgumentValidationPredicate = (argument: string) => boolean;
 type ValidArgumentHandler = (argument: string) => Promise<void>;
 type PreHookCheck = (argument: string[]) => Promise<string | undefined>;

--- a/src/commands/dependency/AbstractDependencyCommand.ts
+++ b/src/commands/dependency/AbstractDependencyCommand.ts
@@ -1,0 +1,40 @@
+import { serviceValidator } from "../../helpers/validator.js";
+import Service from "../../model/Service.js";
+import AbstractStateModificationCommand from "../AbstractStateModificationCommand.js";
+
+type DependencyObjectType = "service" | "system";
+
+export default abstract class AbstractDependencyCommand extends AbstractStateModificationCommand<DependencyObjectType> {
+
+    protected dependencyObjectType: DependencyObjectType;
+    protected logger: (msg: string) => void;
+
+    constructor (argv: string[], config: any, dependencyObjectType: DependencyObjectType) {
+        super(argv, config, dependencyObjectType);
+
+        this.dependencyObjectType = dependencyObjectType;
+        this.logger = (msg: string) => this.log(msg);
+        this.argumentValidationPredicate = serviceValidator(this.inventory, this.error, true);
+    }
+
+    override async run (): Promise<any> {
+        const { argv, flags } = await this.parseArgumentsAndFlags();
+        this.flagValues = flags;
+
+        if (argv.length === 0) {
+            this.error(`${this.dependencyObjectType} not supplied`);
+        }
+
+        for (const argument of argv as string[]) {
+            if (this.argumentValidationPredicate(argument)) {
+                await this.validArgumentHandler(argument);
+            }
+        }
+
+    }
+
+    protected getServiceByName (serviceName: string): Service {
+        return this.inventory.services.find(item => item.name === serviceName) as Service;
+    }
+
+}

--- a/src/commands/dependency/AbstractDependencyCommand.ts
+++ b/src/commands/dependency/AbstractDependencyCommand.ts
@@ -1,14 +1,28 @@
 import { serviceValidator } from "../../helpers/validator.js";
+import { DependencyObjectType } from "../../model/DependencyGraph.js";
 import Service from "../../model/Service.js";
 import AbstractStateModificationCommand from "../AbstractStateModificationCommand.js";
 
-type DependencyObjectType = "service" | "system";
-
+/**
+ * Abstract base class for dependency-related commands.
+ *
+ * Extends {@link AbstractStateModificationCommand} to provide common functionality for commands
+ * that modify a specific dependency object type.
+ *
+ * @template DependencyObjectType - The type of dependency object this command operates on.
+ */
 export default abstract class AbstractDependencyCommand extends AbstractStateModificationCommand<DependencyObjectType> {
 
     protected dependencyObjectType: DependencyObjectType;
     protected logger: (msg: string) => void;
 
+    /**
+     * Constructs an instance of AbstractDependencyCommand.
+     *
+     * @param argv - Command line arguments.
+     * @param config - Configuration object.
+     * @param dependencyObjectType - The type of dependency object this command operates on (e.g., "service" or "system").
+     */
     constructor (argv: string[], config: any, dependencyObjectType: DependencyObjectType) {
         super(argv, config, dependencyObjectType);
 
@@ -33,6 +47,15 @@ export default abstract class AbstractDependencyCommand extends AbstractStateMod
 
     }
 
+    /**
+     * Retrieves a service from the inventory by its name.
+     *
+     * Searches the `inventory.services` array for a service whose `name` property matches
+     * the provided `serviceName`. Returns the matching `Service` instance if found.
+     *
+     * @param serviceName - The name of the service to retrieve.
+     * @returns The `Service` object with the specified name, or `undefined` if not found.
+     */
     protected getServiceByName (serviceName: string): Service {
         return this.inventory.services.find(item => item.name === serviceName) as Service;
     }

--- a/src/commands/dependency/service.ts
+++ b/src/commands/dependency/service.ts
@@ -1,0 +1,61 @@
+import { Args, Config, Flags } from "@oclif/core";
+import AbstractDependencyCommand from "./AbstractDependencyCommand.js";
+import DependencyDiagram from "../../run/dependency/dependency-diagram.js";
+import DependencyTree from "../../run/dependency/dependency-tree.js";
+
+export default class Service extends AbstractDependencyCommand {
+    static description: string = "Generates a dependency diagram / tree for the specified service(s)";
+
+    static args = {
+        services: Args.string({
+            name: "services",
+            required: true,
+            description: "names of services to be graphed"
+        })
+    };
+
+    static flags = {
+        type: Flags.string({
+            char: "t",
+            aliases: ["type"],
+            summary: "diagram / tree / flattree",
+            required: true
+        })
+    };
+
+    private diagram: DependencyDiagram;
+    private tree: DependencyTree;
+
+    constructor (argv: string[], config: Config) {
+        super(argv, config, "service");
+        this.validArgumentHandler = this.handleValidService;
+
+        this.diagram = new DependencyDiagram(this.logger, this.getServiceByName.bind(this));
+        this.tree = new DependencyTree(this.logger, this.getServiceByName.bind(this));
+
+    }
+
+    protected override parseArgumentsAndFlags (): Promise<{
+        argv: unknown[],
+        flags: Record<string, any>
+    }> {
+        return this.parse(Service);
+    }
+
+    private async handleValidService (serviceName: string): Promise<void> {
+
+        if (this.flagValues !== undefined) {
+            const type = this.flagValues?.type || null;
+
+            if (type === "tree") {
+                this.tree.generateTree(serviceName);
+            } else if (type === "flattree") {
+                this.tree.generateFlatTree(serviceName);
+            } else if (type === "diagram") {
+                this.diagram.createDependencyDiagrams(serviceName);
+            } else {
+                this.error(`'${type}' is not a valid value`);
+            }
+        }
+    }
+}

--- a/src/commands/dependency/system.ts
+++ b/src/commands/dependency/system.ts
@@ -1,0 +1,26 @@
+import { Command, Config } from "@oclif/core";
+import { Inventory } from "../../state/inventory.js";
+import loadConfig from "../../helpers/config-loader.js";
+import ChsDevConfig from "../../model/Config.js";
+import DependencyDiagram from "../../run/dependency/dependency-diagram.js";
+
+export default class System extends Command {
+
+    static description: string = "Generates a System dependency Diagram";
+
+    protected readonly inventory: Inventory;
+    private diagram: DependencyDiagram;
+    protected chsDevConfig: ChsDevConfig;
+
+    constructor (argv: string[], config: Config) {
+        super(argv, config);
+        this.chsDevConfig = loadConfig();
+        this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
+        const logger = (msg: string) => this.log(msg);
+        this.diagram = new DependencyDiagram(logger);
+    }
+
+    async run (): Promise<any> {
+        this.diagram.createSystemDiagram(this.inventory);
+    }
+}

--- a/src/commands/dependency/system.ts
+++ b/src/commands/dependency/system.ts
@@ -3,7 +3,15 @@ import { Inventory } from "../../state/inventory.js";
 import loadConfig from "../../helpers/config-loader.js";
 import ChsDevConfig from "../../model/Config.js";
 import DependencyDiagram from "../../run/dependency/dependency-diagram.js";
+import { DependencyObjectType } from "../../model/DependencyGraph.js";
 
+/**
+ * Command to generate a system-wide dependency diagram.
+ * This command allows users to visualize the dependencies of all services
+ * in a CHS Dev project as a single system diagram.
+ * @example
+ * chs-dev dependency system
+ */
 export default class System extends Command {
 
     static description: string = "Generates a System dependency Diagram";
@@ -17,7 +25,7 @@ export default class System extends Command {
         this.chsDevConfig = loadConfig();
         this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
         const logger = (msg: string) => this.log(msg);
-        this.diagram = new DependencyDiagram(logger);
+        this.diagram = new DependencyDiagram(DependencyObjectType.SYSTEM, logger);
     }
 
     async run (): Promise<any> {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,8 @@ import ExclusionsAdd from "./exclusions/add.js";
 import ExclusionsRemove from "./exclusions/remove.js";
 import DevelopmentServices from "./development/services.js";
 import DevelopmentEnable from "./development/enable.js";
+import DependencyService from "./dependency/service.js";
+import DependencySystem from "./dependency/system.js";
 import StateClean from "./state/clean.js";
 import StateCache from "./state/cache.js";
 import StateExport from "./state/export.js";
@@ -46,6 +48,8 @@ export const commands = {
     "services:available": ServicesAvailable,
     "services:enable": ServiceEnable,
     "services:disable": ServiceDisable,
+    "dependency:service": DependencyService,
+    "dependency:system": DependencySystem,
     "modules:available": ModulesAvailable,
     "modules:enable": ModulesEnable,
     "modules:disable": ModulesDisable,

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -130,3 +130,14 @@ export const getCommitCountAheadOfRemote = async (repoPath: string): Promise<num
 
     return Number(await git.raw(["rev-list", "HEAD..@{upstream}", "--count"]));
 };
+
+export const gitSshToHttps = (sshUrl: string): string => {
+    const sshPattern = /^git@([^:]+):(.+?)(\.git)?$/;
+    const match = sshUrl.match(sshPattern);
+    if (!match) {
+        throw new Error("Invalid SSH Git URL format");
+    }
+
+    const [, host, repoPath] = match;
+    return `https://${host}/${repoPath}`;
+};

--- a/src/helpers/github.ts
+++ b/src/helpers/github.ts
@@ -63,6 +63,7 @@ export const createPullRequest = async (
 /**
  * Fetches the GitHub repository description using the gh CLI.
  * @param repository
+ * @param muteError
  * @returns returned as a string, the description of the repository
  */
 export const getRepositoryDescription = (repositoryName: string, muteError = false): string => {
@@ -84,6 +85,7 @@ export const getRepositoryDescription = (repositoryName: string, muteError = fal
 /**
   * Fetches the repository code_owner using the gh CLI.
  * @param repository
+ * @param muteError
  * @returns team-code-owner value
  */
 export const getRespositoryOwner = (repositoryName: string, muteError = false): string => {

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -24,7 +24,7 @@ export const serviceValidator = (inventory: Inventory, error: (message: string) 
     }
 
     if (requireRepository && (service.repository === null || typeof service.repository === "undefined")) {
-        error(`Service "${serviceName}" does not have git repository defined`);
+        error(`Service "${serviceName}" does not have a git repository url defined`);
         return false;
     }
 

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -24,7 +24,7 @@ export const serviceValidator = (inventory: Inventory, error: (message: string) 
     }
 
     if (requireRepository && (service.repository === null || typeof service.repository === "undefined")) {
-        error(`Service "${serviceName}" does not have repository defined`);
+        error(`Service "${serviceName}" does not have git repository defined`);
         return false;
     }
 

--- a/src/model/DependencyGraph.ts
+++ b/src/model/DependencyGraph.ts
@@ -1,0 +1,9 @@
+export enum DependencyObjectType {
+    SERVICE = "service",
+    SYSTEM = "system"
+}
+
+export interface DependencyNode{
+    name: string,
+    dependencies: DependencyNode[];
+}

--- a/src/model/DependencyNode.ts
+++ b/src/model/DependencyNode.ts
@@ -1,0 +1,6 @@
+export interface DependencyNode{
+        name: string,
+        dependencies: DependencyNode[];
+    }
+
+export default DependencyNode;

--- a/src/model/DependencyNode.ts
+++ b/src/model/DependencyNode.ts
@@ -1,6 +1,0 @@
-export interface DependencyNode{
-        name: string,
-        dependencies: DependencyNode[];
-    }
-
-export default DependencyNode;

--- a/src/model/Service.ts
+++ b/src/model/Service.ts
@@ -1,4 +1,5 @@
 import { OrNull } from "./OrNull.js";
+import DependencyNode from "./DependencyNode.js";
 
 /**
  * Represents a service within the development environment. A service is a
@@ -33,6 +34,22 @@ export interface Service {
      */
     dependsOn: string[];
 
+    /**
+     * Tree of the dependencies for the service.
+     *
+     * This will include all of the direct and indirect/transitive dependencies
+     * the service has.
+     */
+    dependencyTree : DependencyNode;
+
+    timesUsedByOtherServices: number;
+    /**
+     * The number of services that depend on this service.
+     *
+     * This is the number of services that have this service in their
+     * `dependsOn` list.
+     */
+    numberOfDependencies: number;
     /**
      * Details about the code repository for the service (required for
      * development mode)

--- a/src/model/Service.ts
+++ b/src/model/Service.ts
@@ -1,5 +1,5 @@
+import { DependencyNode } from "./DependencyGraph.js";
 import { OrNull } from "./OrNull.js";
-import DependencyNode from "./DependencyNode.js";
 
 /**
  * Represents a service within the development environment. A service is a
@@ -42,12 +42,20 @@ export interface Service {
      */
     dependencyTree?: DependencyNode;
 
+    /**
+     * The number of times this service is used by other services.
+     *
+     * This is the number of services that have this service in their `dependsOn` list and
+     * is not the same as `numberOfDependencies` which counts the number of
+     * services that the service depends on.
+     */
     timesUsedByOtherServices?: number;
     /**
      * The number of services that depend on this service.
      *
-     * This is the number of services that have this service in their
-     * `dependsOn` list.
+     * This is the number of services that this service depends on either directly or
+     * indirectly. This is not the same as `timesUsedByOtherServices` which counts
+     * the number of time a service appears on the `dependsOn` list.
      */
     numberOfDependencies?: number;
     /**

--- a/src/model/Service.ts
+++ b/src/model/Service.ts
@@ -40,16 +40,16 @@ export interface Service {
      * This will include all of the direct and indirect/transitive dependencies
      * the service has.
      */
-    dependencyTree : DependencyNode;
+    dependencyTree?: DependencyNode;
 
-    timesUsedByOtherServices: number;
+    timesUsedByOtherServices?: number;
     /**
      * The number of services that depend on this service.
      *
      * This is the number of services that have this service in their
      * `dependsOn` list.
      */
-    numberOfDependencies: number;
+    numberOfDependencies?: number;
     /**
      * Details about the code repository for the service (required for
      * development mode)

--- a/src/run/dependency/AbstractDependencyGraph.ts
+++ b/src/run/dependency/AbstractDependencyGraph.ts
@@ -10,6 +10,13 @@ export type ServiceFinder = (argument: string) => Service | ServiceGitDescriptio
 
 const defaultServiceFinder: ServiceFinder = (_: string): Service | undefined => undefined;
 
+/**
+ * Abstract base class for representing a dependency graph of services.
+ * Provides mechanisms for finding services and retrieving their Git descriptions and owners.
+ * @property serviceFinder - Utility for locating services, defaults to {@link defaultServiceFinder}.
+ *
+ * @param serviceFinder - Optional custom service finder to override the default.
+ */
 export default abstract class AbstractDependencyGraph {
 
     protected serviceFinder: ServiceFinder = defaultServiceFinder;
@@ -18,6 +25,16 @@ export default abstract class AbstractDependencyGraph {
         this.serviceFinder = serviceFinder ?? defaultServiceFinder;
     }
 
+    /**
+     * Retrieves the Git description and owner information for a given service.
+     *
+     * @param service - The service for which to obtain Git metadata.
+     * @returns An object containing the service's properties, Git description, and team owner.
+     *
+     * @remarks
+     * If the service's module is "infrastructure" or "open-telemetry", default values are used.
+     * If the repository URL is unavailable, fallback values are provided.
+     */
     protected getServiceGitDescriptionAndOwner = (service: Service): ServiceGitDescriptionAndOwner => {
         const repoUrl = service.repository?.url;
         let gitDescription;

--- a/src/run/dependency/AbstractDependencyGraph.ts
+++ b/src/run/dependency/AbstractDependencyGraph.ts
@@ -1,0 +1,39 @@
+import { getRepositoryDescription, getRespositoryOwner } from "../../helpers/github.js";
+import Service from "../../model/Service.js";
+
+export type Logger = (msg: string) => void;
+export type ServiceGitDescriptionAndOwner = Service & {
+    gitDescription: string;
+    teamOwner: string;
+};
+export type ServiceFinder = (argument: string) => Service | ServiceGitDescriptionAndOwner | undefined;
+
+const defaultServiceFinder: ServiceFinder = (_: string): Service | undefined => undefined;
+
+export default abstract class AbstractDependencyGraph {
+
+    protected serviceFinder: ServiceFinder = defaultServiceFinder;
+
+    constructor (serviceFinder?: ServiceFinder) {
+        this.serviceFinder = serviceFinder ?? defaultServiceFinder;
+    }
+
+    protected getServiceGitDescriptionAndOwner = (service: Service): ServiceGitDescriptionAndOwner => {
+        const repoUrl = service.repository?.url;
+        let gitDescription;
+        let teamOwner;
+
+        if (repoUrl) {
+            const MuteError = true;
+            const gitServiceName = repoUrl.replace(/\.git$/, "").split("/").pop() as string;
+            gitDescription = service.module !== "infrastructure" && service.module !== "open-telemetry" ? getRepositoryDescription(gitServiceName, MuteError) : "infrastructure service";
+            teamOwner = service.module !== "infrastructure" && service.module !== "open-telemetry" ? getRespositoryOwner(gitServiceName, MuteError) : "infrastructure service";
+        }
+        return {
+            ...service,
+            gitDescription: gitDescription ?? "Service Description Unavailable",
+            teamOwner: teamOwner ?? "Service Owner Unavailable"
+        };
+    };
+
+}

--- a/src/run/dependency/dependency-diagram.ts
+++ b/src/run/dependency/dependency-diagram.ts
@@ -1,0 +1,107 @@
+import { writeFileSync } from "fs";
+import AbstractDependencyGraph, { Logger, ServiceFinder, ServiceGitDescriptionAndOwner } from "./AbstractDependencyGraph.js";
+import DependencyNode from "../../model/DependencyNode.js";
+import { graphviz } from "node-graphviz";
+import open from "open";
+import Service from "../../model/Service.js";
+import { Inventory } from "../../state/inventory.js";
+
+type TraveseType = "service" | "system"
+
+export default class DependencyDiagram extends AbstractDependencyGraph {
+
+    private logger: Logger;
+
+    constructor (logger: Logger, serviceFinder?: ServiceFinder) {
+        super(serviceFinder);
+        this.logger = logger;
+    }
+
+    private generateDotHeader (diagramName: string, options: { rankdir?: string, ranksep?: number, splines?: string, nodesep?: number, fontsize?: number, height?: number, width?: number } = {}): string {
+        let dot = `digraph ${diagramName} {\n`;
+        dot += `graph [rankdir=${options.rankdir ?? "TB"}${options.splines ? `, splines=${options.splines}` : ""}${options.nodesep ? `, nodesep=${options.nodesep}` : ""}${options.ranksep ? `, ranksep=${options.ranksep}` : ""}]\n`;
+        dot += `node [shape=box, style=filled, color=lightblue2${options.fontsize ? `, fontsize=${options.fontsize}` : ""}${options.height ? `, height=${options.height}` : ""}${options.width ? `, width=${options.width}` : ""}]\n`;
+        return dot;
+    }
+
+    private async generateAndOpenDiagram (dot: string, diagramPath: string, layout: "dot" | "fdp" = "dot") {
+        try {
+            const svg = layout === "dot"
+                ? await graphviz.dot(dot, "svg")
+                : await graphviz.fdp(dot, "svg");
+            writeFileSync(diagramPath, svg);
+            open(diagramPath);
+        } catch (error) {
+            this.logger(`An error occurred: ${error}`);
+        }
+    }
+
+    createDependencyDiagrams (serviceOrServiceName: string | Service): void {
+        const service = typeof serviceOrServiceName === "string"
+            ? this.serviceFinder(serviceOrServiceName)
+            : serviceOrServiceName as Service;
+
+        if (service !== undefined) {
+            const serviceName = service.name;
+            this.logger(`Creating dependency diagram for service: ${serviceName}`);
+
+            let dot = this.generateDotHeader("ServiceDependencyDiagram", { rankdir: "TB", ranksep: 2.5 });
+            const seenEdges = new Set<string>();
+            dot = this.handleTraverse(service.dependencyTree, dot, seenEdges);
+            dot += "}";
+
+            const DIAGRAM_PATH = `./local/${serviceName}-dependency_diagram.svg`;
+            this.generateAndOpenDiagram(dot, DIAGRAM_PATH, "dot");
+        }
+    }
+
+    createSystemDiagram (inventory: Inventory) {
+        this.logger("Creating system dependency diagram");
+        let dot = this.generateDotHeader("SystemDependencyDiagram", {
+            rankdir: "TB",
+            splines: "polyline",
+            nodesep: 5,
+            ranksep: 20,
+            fontsize: 75,
+            height: 3,
+            width: 7
+        });
+
+        const seenEdges = new Set<string>();
+
+        inventory.services.forEach(service => {
+            dot = this.handleTraverse(service.dependencyTree, dot, seenEdges, "system");
+        });
+
+        dot += "}\n";
+        const DIAGRAM_PATH = `./local/system-dependency_diagram.svg`;
+        this.generateAndOpenDiagram(dot, DIAGRAM_PATH, "fdp");
+    }
+
+    handleTraverse (node: DependencyNode, dot: string, seenEdges: Set<string>, traveseType: TraveseType = "service"): string {
+        if (!node) return dot;
+
+        if (!seenEdges.has(`"${node.name}"`)) {
+            seenEdges.add(`"${node.name}"`);
+            if (traveseType === "service") {
+                let nodeService = this.serviceFinder(node.name) as ServiceGitDescriptionAndOwner;
+                if (nodeService) {
+                    nodeService = this.getServiceGitDescriptionAndOwner(nodeService);
+                    const tooltip = `Description: ${nodeService.gitDescription?.trim()}\nOwner: ${nodeService.teamOwner?.trim()}\nDependencies: ${nodeService.numberOfDependencies}\nUsed By: ${nodeService.timesUsedByOtherServices} service(s)\n`;
+                    dot += `"${node.name}" [label="${node.name}", tooltip="${tooltip}", href="#"]\n`;
+                }
+            }
+        }
+
+        node.dependencies.forEach(childNode => {
+            const edgeString = `"${node.name}" -> "${childNode.name}"`;
+            if (!seenEdges.has(edgeString)) {
+                seenEdges.add(edgeString);
+                dot += `${edgeString}\n`;
+            }
+            dot = this.handleTraverse(childNode, dot, seenEdges);
+        });
+
+        return dot;
+    }
+}

--- a/src/run/dependency/dependency-diagram.ts
+++ b/src/run/dependency/dependency-diagram.ts
@@ -1,41 +1,43 @@
 import { writeFileSync } from "fs";
 import AbstractDependencyGraph, { Logger, ServiceFinder, ServiceGitDescriptionAndOwner } from "./AbstractDependencyGraph.js";
-import DependencyNode from "../../model/DependencyNode.js";
+
 import { graphviz } from "node-graphviz";
 import open from "open";
 import Service from "../../model/Service.js";
 import { Inventory } from "../../state/inventory.js";
+import { GraphBuilder, GraphOptions } from "../graph-builder.js";
+import { DependencyNode, DependencyObjectType } from "../../model/DependencyGraph.js";
 
-type TraveseType = "service" | "system"
-
+/**
+ * DependencyDiagram generates visual diagrams of service or system dependencies.
+ */
 export default class DependencyDiagram extends AbstractDependencyGraph {
 
-    private logger: Logger;
+    private readonly builder: GraphBuilder;
+    private readonly dependencyObjectType:DependencyObjectType;
+    private readonly logger: Logger;
 
-    constructor (logger: Logger, serviceFinder?: ServiceFinder) {
+    /**
+     * Constructs a DependencyDiagram instance.
+     * @param dependencyObjectType - Type of diagram ("service" or "system")
+     * @param logger - Logging function
+     * @param serviceFinder - Optional service lookup function
+     */
+    constructor (
+        dependencyObjectType:DependencyObjectType,
+        logger: Logger,
+        serviceFinder?: ServiceFinder
+    ) {
         super(serviceFinder);
         this.logger = logger;
+        this.dependencyObjectType = dependencyObjectType;
+        this.builder = this.createGraphBuilder();
     }
 
-    private generateDotHeader (diagramName: string, options: { rankdir?: string, ranksep?: number, splines?: string, nodesep?: number, fontsize?: number, height?: number, width?: number } = {}): string {
-        let dot = `digraph ${diagramName} {\n`;
-        dot += `graph [rankdir=${options.rankdir ?? "TB"}${options.splines ? `, splines=${options.splines}` : ""}${options.nodesep ? `, nodesep=${options.nodesep}` : ""}${options.ranksep ? `, ranksep=${options.ranksep}` : ""}]\n`;
-        dot += `node [shape=box, style=filled, color=lightblue2${options.fontsize ? `, fontsize=${options.fontsize}` : ""}${options.height ? `, height=${options.height}` : ""}${options.width ? `, width=${options.width}` : ""}]\n`;
-        return dot;
-    }
-
-    private async generateAndOpenDiagram (dot: string, diagramPath: string, layout: "dot" | "fdp" = "dot") {
-        try {
-            const svg = layout === "dot"
-                ? await graphviz.dot(dot, "svg")
-                : await graphviz.fdp(dot, "svg");
-            writeFileSync(diagramPath, svg);
-            open(diagramPath);
-        } catch (error) {
-            this.logger(`An error occurred: ${error}`);
-        }
-    }
-
+    /**
+     * Creates a dependency diagram for a specific service.
+     * @param serviceOrServiceName - Service object or service name string
+     */
     createDependencyDiagrams (serviceOrServiceName: string | Service): void {
         const service = typeof serviceOrServiceName === "string"
             ? this.serviceFinder(serviceOrServiceName)
@@ -44,51 +46,48 @@ export default class DependencyDiagram extends AbstractDependencyGraph {
         if (service !== undefined) {
             const serviceName = service.name;
             this.logger(`Creating dependency diagram for service: ${serviceName}`);
-
-            let dot = this.generateDotHeader("ServiceDependencyDiagram", { rankdir: "TB", ranksep: 2.5 });
             const seenEdges = new Set<string>();
-            dot = this.handleTraverse(service.dependencyTree as DependencyNode, dot, seenEdges);
-            dot += "}";
+            this.handleTraverse(service.dependencyTree as DependencyNode, this.builder, seenEdges);
+            const dot = this.builder.build();
 
             const DIAGRAM_PATH = `./local/${serviceName}-dependency_diagram.svg`;
             this.generateAndOpenDiagram(dot, DIAGRAM_PATH, "dot");
         }
     }
 
+    /**
+     * Creates a system-wide dependency diagram for all services in the inventory.
+     * @param inventory - Inventory containing all services
+     */
     createSystemDiagram (inventory: Inventory) {
         this.logger("Creating system dependency diagram");
-        let dot = this.generateDotHeader("SystemDependencyDiagram", {
-            rankdir: "TB",
-            splines: "polyline",
-            nodesep: 5,
-            ranksep: 20,
-            fontsize: 75,
-            height: 3,
-            width: 7
-        });
-
         const seenEdges = new Set<string>();
-
         inventory.services.forEach(service => {
-            dot = this.handleTraverse(service.dependencyTree as DependencyNode, dot, seenEdges, "system");
+            this.handleTraverse(service.dependencyTree as DependencyNode, this.builder, seenEdges);
         });
 
-        dot += "}\n";
+        const fdp = this.builder.build();
         const DIAGRAM_PATH = `./local/system-dependency_diagram.svg`;
-        this.generateAndOpenDiagram(dot, DIAGRAM_PATH, "fdp");
+        this.generateAndOpenDiagram(fdp, DIAGRAM_PATH, "fdp");
     }
 
-    handleTraverse (node: DependencyNode, dot: string, seenEdges: Set<string>, traveseType: TraveseType = "service"): string {
-        if (!node) return dot;
+    /**
+     * Traverses the dependency tree and adds nodes/edges to the graph builder.
+     * @param node - Current dependency node
+     * @param builder - GraphBuilder instance
+     * @param seenEdges - Set to track visited nodes/edges
+     */
+    handleTraverse (node: DependencyNode, builder: GraphBuilder, seenEdges: Set<string>): void {
+        if (!node) return;
 
         if (!seenEdges.has(`"${node.name}"`)) {
             seenEdges.add(`"${node.name}"`);
-            if (traveseType === "service") {
+            if (this.dependencyObjectType === DependencyObjectType.SERVICE) {
                 let nodeService = this.serviceFinder(node.name) as ServiceGitDescriptionAndOwner;
                 if (nodeService) {
                     nodeService = this.getServiceGitDescriptionAndOwner(nodeService);
-                    const tooltip = `Description: ${nodeService.gitDescription?.trim()}\nOwner: ${nodeService.teamOwner?.trim()}\nDependencies: ${nodeService.numberOfDependencies}\nUsed By: ${nodeService.timesUsedByOtherServices} service(s)\n`;
-                    dot += `"${node.name}" [label="${node.name}", tooltip="${tooltip}", href="#"]\n`;
+                    const tooltip = `Name: ${nodeService.name.trim().toUpperCase()}\nDescription: ${nodeService.gitDescription?.trim()}\nOwner: ${nodeService.teamOwner?.trim()}\nDependencies: ${nodeService.numberOfDependencies}\nUsed By: ${nodeService.timesUsedByOtherServices} service(s)\n`;
+                    builder.addNode(node.name, node.name, tooltip, "#");
                 }
             }
         }
@@ -97,11 +96,49 @@ export default class DependencyDiagram extends AbstractDependencyGraph {
             const edgeString = `"${node.name}" -> "${childNode.name}"`;
             if (!seenEdges.has(edgeString)) {
                 seenEdges.add(edgeString);
-                dot += `${edgeString}\n`;
+                builder.addEdge(node.name, childNode.name);
             }
-            dot = this.handleTraverse(childNode, dot, seenEdges);
+            this.handleTraverse(childNode, builder, seenEdges);
         });
-
-        return dot;
     }
+
+    /**
+     * Creates a GraphBuilder instance with options based on diagram type.
+     * @returns GraphBuilder instance
+     */
+    private createGraphBuilder (): GraphBuilder {
+        const options: GraphOptions = this.dependencyObjectType === DependencyObjectType.SERVICE
+            ? { layout: "dot", rankdir: "TB", ranksep: 2.5 }
+            : {
+                layout: "fdp",
+                rankdir: "TB",
+                splines: "polyline",
+                nodesep: 5,
+                ranksep: 20,
+                fontsize: 75,
+                height: 3,
+                width: 7
+            };
+        const diagramName = this.dependencyObjectType === DependencyObjectType.SERVICE ? "ServiceDependencyDiagram" : "SystemDependencyDiagram";
+        return new GraphBuilder(diagramName, options);
+    }
+
+    /**
+     * Generates an SVG diagram from DOT/Graphviz lines and opens it.
+     * @param lines - DOT/Graphviz source string
+     * @param diagramPath - Output file path
+     * @param layout - Graphviz layout engine ("dot" or "fdp")
+     */
+    private async generateAndOpenDiagram (lines: string, diagramPath: string, layout: "dot" | "fdp") {
+        try {
+            const svg = layout === "dot"
+                ? await graphviz.dot(lines, "svg")
+                : await graphviz.fdp(lines, "svg");
+            writeFileSync(diagramPath, svg);
+            open(diagramPath);
+        } catch (error) {
+            this.logger(`An error occurred: ${error}`);
+        }
+    }
+
 }

--- a/src/run/dependency/dependency-diagram.ts
+++ b/src/run/dependency/dependency-diagram.ts
@@ -47,7 +47,7 @@ export default class DependencyDiagram extends AbstractDependencyGraph {
 
             let dot = this.generateDotHeader("ServiceDependencyDiagram", { rankdir: "TB", ranksep: 2.5 });
             const seenEdges = new Set<string>();
-            dot = this.handleTraverse(service.dependencyTree, dot, seenEdges);
+            dot = this.handleTraverse(service.dependencyTree as DependencyNode, dot, seenEdges);
             dot += "}";
 
             const DIAGRAM_PATH = `./local/${serviceName}-dependency_diagram.svg`;
@@ -70,7 +70,7 @@ export default class DependencyDiagram extends AbstractDependencyGraph {
         const seenEdges = new Set<string>();
 
         inventory.services.forEach(service => {
-            dot = this.handleTraverse(service.dependencyTree, dot, seenEdges, "system");
+            dot = this.handleTraverse(service.dependencyTree as DependencyNode, dot, seenEdges, "system");
         });
 
         dot += "}\n";

--- a/src/run/dependency/dependency-diagram.ts
+++ b/src/run/dependency/dependency-diagram.ts
@@ -7,6 +7,7 @@ import Service from "../../model/Service.js";
 import { Inventory } from "../../state/inventory.js";
 import { GraphBuilder, GraphOptions } from "../graph-builder.js";
 import { DependencyNode, DependencyObjectType } from "../../model/DependencyGraph.js";
+import { gitSshToHttps } from "../../helpers/git.js";
 
 /**
  * DependencyDiagram generates visual diagrams of service or system dependencies.
@@ -85,9 +86,10 @@ export default class DependencyDiagram extends AbstractDependencyGraph {
             if (this.dependencyObjectType === DependencyObjectType.SERVICE) {
                 let nodeService = this.serviceFinder(node.name) as ServiceGitDescriptionAndOwner;
                 if (nodeService) {
+                    const repositoryUrl = nodeService.repository?.url ? gitSshToHttps(nodeService.repository.url) : "#";
                     nodeService = this.getServiceGitDescriptionAndOwner(nodeService);
                     const tooltip = `Name: ${nodeService.name.trim().toUpperCase()}\nDescription: ${nodeService.gitDescription?.trim()}\nOwner: ${nodeService.teamOwner?.trim()}\nDependencies: ${nodeService.numberOfDependencies}\nUsed By: ${nodeService.timesUsedByOtherServices} service(s)\n`;
-                    builder.addNode(node.name, node.name, tooltip, "#");
+                    builder.addNode(node.name, node.name, tooltip, repositoryUrl);
                 }
             }
         }

--- a/src/run/dependency/dependency-tree.ts
+++ b/src/run/dependency/dependency-tree.ts
@@ -1,0 +1,92 @@
+import { simpleColouriser } from "../../helpers/colouriser.js";
+import DependencyNode from "../../model/DependencyNode.js";
+import AbstractDependencyGraph, { Logger, ServiceFinder } from "./AbstractDependencyGraph.js";
+
+export default class DependencyTree extends AbstractDependencyGraph {
+
+    private logger: (msg: string) => void;
+
+    constructor (logger: Logger, serviceFinder: ServiceFinder) {
+        super(serviceFinder);
+        this.logger = logger;
+    }
+
+    generateTree = (serviceName : string) => {
+        const service = this.serviceFinder(serviceName);
+        if (service !== undefined) {
+            let lines: string[] = [];
+            const edges = new Set<string>();
+            lines = this.handleTraverseTree(service.dependencyTree, lines, edges, "", true, 0);
+            this.logger(lines.join("\n"));
+        }
+    };
+
+    generateFlatTree = (serviceName : string) => {
+        const service = this.serviceFinder(serviceName);
+        if (service !== undefined) {
+            let services = this.handleTraverseFlatTree(service.dependencyTree);
+            services = Array.from(new Set(services.split("\n").filter(line => line.trim() !== "").map((line, index) => (index === 0 ? line.trim() : "\t" + line.trim())))).join("\n");
+            this.logger(services);
+        }
+    };
+
+    handleTraverseTree (
+        node: DependencyNode,
+        lines: string[],
+        edges: Set<string>,
+        prefix: string,
+        isLast: boolean,
+        depth: number = 0
+    ): string[] {
+
+        if (!node) return lines;
+
+        const branch = isLast ? "└── " : "├── ";
+        const linePrefix = prefix + branch;
+
+        const isDuplicate = edges.has(node.name);
+
+        let coloredName: string;
+        if (isDuplicate && depth > 1) {
+            coloredName = simpleColouriser(`${node.name} (shared dependency)`, "gray");
+        } else if (depth === 0) {
+            coloredName = simpleColouriser(node.name, "red"); // root
+        } else if (depth === 1) {
+            coloredName = simpleColouriser(node.name, "yellow"); // direct dependency
+        } else {
+            coloredName = simpleColouriser(node.name, "green"); // subdependency
+        }
+
+        lines.push(linePrefix + coloredName);
+
+        if (isDuplicate) return lines;
+
+        edges.add(node.name);
+
+        const deps = node.dependencies || [];
+        const newPrefix = prefix + (isLast ? "    " : "│   ");
+
+        deps.forEach((child, index) => {
+            lines = this.handleTraverseTree(child, lines, edges, newPrefix, index === deps.length - 1, depth + 1);
+        });
+        return lines;
+    }
+
+    handleTraverseFlatTree (dependencyTree: DependencyNode) {
+        let output = "";
+        const space = "";
+        function traverse (node : DependencyNode, space : string) {
+            if (!node) {
+                return;
+            }
+
+            let line = space;
+            line += node.name;
+            output += line + "\n";
+            space += "    ";
+            node.dependencies.forEach(childNode => traverse(childNode, space));
+        }
+        traverse(dependencyTree, space);
+        return output;
+    }
+}

--- a/src/run/dependency/dependency-tree.ts
+++ b/src/run/dependency/dependency-tree.ts
@@ -1,16 +1,29 @@
 import { simpleColouriser } from "../../helpers/colouriser.js";
-import DependencyNode from "../../model/DependencyNode.js";
+import { DependencyNode } from "../../model/DependencyGraph.js";
 import AbstractDependencyGraph, { Logger, ServiceFinder } from "./AbstractDependencyGraph.js";
 
+/**
+ * DependencyTree extends AbstractDependencyGraph to provide
+ * methods for generating and displaying dependency trees.
+ */
 export default class DependencyTree extends AbstractDependencyGraph {
 
     private logger: (msg: string) => void;
 
+    /**
+     * Constructs a DependencyTree with a logger and service finder.
+     * @param logger - Function to log output.
+     * @param serviceFinder - Function to find services by name.
+     */
     constructor (logger: Logger, serviceFinder: ServiceFinder) {
         super(serviceFinder);
         this.logger = logger;
     }
 
+    /**
+     * Generates and logs a formatted dependency tree for a given service.
+     * @param serviceName - Name of the service to generate the tree for.
+     */
     generateTree = (serviceName : string) => {
         const service = this.serviceFinder(serviceName);
         if (service !== undefined) {
@@ -21,6 +34,10 @@ export default class DependencyTree extends AbstractDependencyGraph {
         }
     };
 
+    /**
+     * Generates and logs a flat list of all dependencies for a given service.
+     * @param serviceName - Name of the service to generate the flat tree for.
+     */
     generateFlatTree = (serviceName : string) => {
         const service = this.serviceFinder(serviceName);
         if (service !== undefined) {
@@ -30,6 +47,16 @@ export default class DependencyTree extends AbstractDependencyGraph {
         }
     };
 
+    /**
+     * Recursively traverses the dependency tree and builds a formatted tree structure.
+     * @param node - Current dependency node.
+     * @param lines - Accumulated lines of the tree.
+     * @param edges - Set of visited node names to detect duplicates.
+     * @param prefix - Prefix for formatting tree branches.
+     * @param isLast - Whether the node is the last child.
+     * @param depth - Current depth in the tree.
+     * @returns Array of formatted tree lines.
+     */
     handleTraverseTree (
         node: DependencyNode,
         lines: string[],
@@ -72,6 +99,11 @@ export default class DependencyTree extends AbstractDependencyGraph {
         return lines;
     }
 
+    /**
+     * Recursively traverses the dependency tree and builds a flat list of all dependencies.
+     * @param dependencyTree - Root dependency node.
+     * @returns String containing all dependencies in a flat format.
+     */
     handleTraverseFlatTree (dependencyTree: DependencyNode) {
         let output = "";
         const space = "";

--- a/src/run/dependency/dependency-tree.ts
+++ b/src/run/dependency/dependency-tree.ts
@@ -16,7 +16,7 @@ export default class DependencyTree extends AbstractDependencyGraph {
         if (service !== undefined) {
             let lines: string[] = [];
             const edges = new Set<string>();
-            lines = this.handleTraverseTree(service.dependencyTree, lines, edges, "", true, 0);
+            lines = this.handleTraverseTree(service.dependencyTree as DependencyNode, lines, edges, "", true, 0);
             this.logger(lines.join("\n"));
         }
     };
@@ -24,7 +24,7 @@ export default class DependencyTree extends AbstractDependencyGraph {
     generateFlatTree = (serviceName : string) => {
         const service = this.serviceFinder(serviceName);
         if (service !== undefined) {
-            let services = this.handleTraverseFlatTree(service.dependencyTree);
+            let services = this.handleTraverseFlatTree(service.dependencyTree as DependencyNode);
             services = Array.from(new Set(services.split("\n").filter(line => line.trim() !== "").map((line, index) => (index === 0 ? line.trim() : "\t" + line.trim())))).join("\n");
             this.logger(services);
         }

--- a/src/run/graph-builder.ts
+++ b/src/run/graph-builder.ts
@@ -1,0 +1,82 @@
+export type Layout = "dot" | "fdp";
+
+export type GraphOptions =
+    | { layout: "dot"; rankdir: string; ranksep: number }
+    | {
+          layout: "fdp";
+          rankdir: string;
+          splines: string;
+          nodesep: number;
+          ranksep: number;
+          fontsize: number;
+          height: number;
+          width: number;
+      };
+
+/**
+ * GraphBuilder is responsible for constructing a DOT or FDP graph representation.
+ * It allows adding nodes and edges with various attributes and generates the final DOT or FDP  source.
+ */
+export class GraphBuilder {
+    private diagramName: string;
+    private options: GraphOptions;
+    private lines: string[] = [];
+
+    /**
+     * Initializes a new GraphBuilder instance.
+     * @param diagramName - Name of the diagram
+     * @param options - Graph options including layout type and attributes
+     */
+    constructor (diagramName: string, options: GraphOptions) {
+        this.diagramName = diagramName;
+        this.options = options;
+        this.lines.push(`digraph ${diagramName} {`);
+        this.addGraphAttributes();
+        this.addNodeAttributes();
+    }
+
+    // Adds graph-level attributes based on layout type
+    private addGraphAttributes () {
+        if (this.options.layout === "dot") {
+            const { rankdir, ranksep } = this.options;
+            const attrs = `graph [rankdir=${rankdir}, ranksep=${ranksep}]`;
+            this.lines.push(attrs);
+        } else {
+            const { rankdir, splines, nodesep, ranksep } = this.options;
+            const attrs = `graph [rankdir=${rankdir}, splines=${splines}, nodesep=${nodesep}, ranksep=${ranksep}]`;
+            this.lines.push(attrs);
+        }
+    }
+
+    // Adds node-level attributes based on layout type
+    private addNodeAttributes () {
+        if (this.options.layout === "dot") {
+            this.lines.push(`node [shape=box, style=filled, color=lightblue2]`);
+        } else {
+            const { fontsize, height, width } = this.options;
+            const attrs = `node [shape=box, style=filled, color=lightblue2, fontsize=${fontsize}, height=${height}, width=${width}]`;
+            this.lines.push(attrs);
+        }
+    }
+
+    // Adds a node to the graph with optional label, tooltip, and hyperlink
+    addNode (name: string, label?: string, tooltip?: string, href?: string) {
+        let nodeStr = `"${name}"`;
+        const attrs: string[] = [];
+        if (label) attrs.push(`label="${label}"`);
+        if (tooltip) attrs.push(`tooltip="${tooltip}"`);
+        if (href) attrs.push(`href="${href}"`);
+        if (attrs.length) nodeStr += ` [${attrs.join(", ")}]`;
+        this.lines.push(nodeStr);
+    }
+
+    // Adds a directed edge between two nodes
+    addEdge (from: string, to: string) {
+        this.lines.push(`"${from}" -> "${to}"`);
+    }
+
+    // Builds and returns the DOT graph as a string
+    build (): string {
+        return this.lines.join("\n") + "\n}";
+    }
+}

--- a/src/run/graph-builder.ts
+++ b/src/run/graph-builder.ts
@@ -65,7 +65,7 @@ export class GraphBuilder {
         const attrs: string[] = [];
         if (label) attrs.push(`label="${label}"`);
         if (tooltip) attrs.push(`tooltip="${tooltip}"`);
-        if (href) attrs.push(`href="${href}"`);
+        if (href) attrs.push(`href="${href}", target="_blank"`);
         if (attrs.length) nodeStr += ` [${attrs.join(", ")}]`;
         this.lines.push(nodeStr);
     }

--- a/src/state/dependency-tree-builder.ts
+++ b/src/state/dependency-tree-builder.ts
@@ -1,0 +1,42 @@
+import Service from "../model/Service.js";
+import DependencyTree, { DependencyNode } from "../model/DependencyNode.js";
+
+/**
+ * Will resolve a Service's full list of dependencies including any transitive
+ * dependencies and create a tree structure
+ */
+export class DependencyTreeBuilder {
+
+    private readonly allServices: Partial<Service>[];
+
+    constructor (allServices: Partial<Service>[]) {
+        this.allServices = allServices;
+    }
+
+    /**
+     * Resolves the dependency tree for the supplied service.
+     * @param serviceName ServiceName to produce a dependency tree for
+     * @returns A complete dependency tree for the specified service
+     */
+    dependencyTree (serviceName: string, seen = new Set()): DependencyTree {
+
+        const NO_DEPENDENCIES : DependencyNode = { name: serviceName, dependencies: [] };
+
+        if (seen.has(serviceName)) {
+            return NO_DEPENDENCIES;
+        }
+        seen.add(serviceName);
+        const service = this.allServices.find(item => item.name === serviceName);
+
+        if (!service || !service.dependsOn) {
+            return NO_DEPENDENCIES;
+        }
+
+        const tree = {
+            name: serviceName,
+            dependencies: service.dependsOn.map(dependency => this.dependencyTree(dependency, new Set(seen)))
+        };
+
+        return tree;
+    }
+}

--- a/src/state/dependency-tree-builder.ts
+++ b/src/state/dependency-tree-builder.ts
@@ -1,5 +1,5 @@
 import Service from "../model/Service.js";
-import DependencyTree, { DependencyNode } from "../model/DependencyNode.js";
+import { DependencyNode } from "../model/DependencyGraph.js";
 
 /**
  * Will resolve a Service's full list of dependencies including any transitive
@@ -18,7 +18,7 @@ export class DependencyTreeBuilder {
      * @param serviceName ServiceName to produce a dependency tree for
      * @returns A complete dependency tree for the specified service
      */
-    dependencyTree (serviceName: string, seen = new Set()): DependencyTree {
+    dependencyTree (serviceName: string, seen = new Set()): DependencyNode {
 
         const NO_DEPENDENCIES : DependencyNode = { name: serviceName, dependencies: [] };
 

--- a/src/state/inventory.ts
+++ b/src/state/inventory.ts
@@ -100,7 +100,7 @@ export class Inventory {
             let count = 0;
             services.forEach(service => {
                 if (service.name !== dependency.name) {
-                    count = count + this.addTimesReferenced(service.dependencyTree, dependency.name);
+                    count = count + this.addTimesReferenced(service.dependencyTree as DependencyNode, dependency.name);
                 }
             });
             dependency.timesUsedByOtherServices = count;

--- a/src/state/inventory.ts
+++ b/src/state/inventory.ts
@@ -9,6 +9,8 @@ import { Service } from "../model/Service.js";
 import { Module } from "../model/Module.js";
 import { readServices } from "./service-reader.js";
 import { DependencyNameResolver } from "./dependency-name-resolver.js";
+import { DependencyTreeBuilder } from "./dependency-tree-builder.js";
+import DependencyNode from "../model/DependencyNode.js";
 
 interface InventoryCache {
   hash: string;
@@ -23,7 +25,6 @@ export class Inventory {
     constructor (private path: string, cacheDir: string) {
         this.path = path;
         this.inventoryCacheFile = join(cacheDir, `${basename(path)}.inventory.yaml`);
-
         if (!existsSync(cacheDir)) {
             mkdirSync(cacheDir, {
                 recursive: true
@@ -43,11 +44,10 @@ export class Inventory {
         const inventoryCache = this.inventoryCache;
 
         if (typeof inventoryCache !== "undefined") {
-            if (inventoryCache.hash === this.hashServiceFiles()) {
+            if (inventoryCache.hash === this.hashServiceCacheObject()) {
                 return cacheSupplier(inventoryCache);
             }
         }
-
         this.updateCache();
 
         return this.getFromCache(cacheSupplier);
@@ -55,7 +55,7 @@ export class Inventory {
 
     private updateCache () {
         const inventory = {
-            hash: this.hashServiceFiles(),
+            hash: this.hashServiceCacheObject(),
             services: this.loadServices(),
             modules: this.loadModules()
         };
@@ -73,25 +73,61 @@ export class Inventory {
             });
     }
 
-    private loadServices (): Service[] {
+    private get __servicesCacheObject (): Service[] {
         const partialServices: Partial<Service>[] = this.serviceFiles.flatMap(readServices);
-
         const dependencyNameResolver = new DependencyNameResolver(partialServices);
 
-        return partialServices.map(service => ({
-            ...service,
-            dependsOn: dependencyNameResolver.fullDependencyListIncludingTransitive(service.dependsOn as string[])
-        } as Service));
+        const dependencyTreeBuilder = new DependencyTreeBuilder(partialServices);
+
+        return partialServices.map(service => {
+            const fullDependencyList = dependencyNameResolver.fullDependencyListIncludingTransitive(
+                Array.isArray(service.dependsOn) ? service.dependsOn as string[] : []
+            );
+
+            return {
+                ...service,
+                dependencyTree: dependencyTreeBuilder.dependencyTree(service.name as string),
+                dependsOn: fullDependencyList,
+                numberOfDependencies: fullDependencyList.length
+            } as Service;
+        });
     }
 
-    private hashServiceFiles () {
+    private loadServices (): Service[] {
+        const services: Service[] = this.__servicesCacheObject;
+
+        services.forEach(dependency => {
+            let count = 0;
+            services.forEach(service => {
+                if (service.name !== dependency.name) {
+                    count = count + this.addTimesReferenced(service.dependencyTree, dependency.name);
+                }
+            });
+            dependency.timesUsedByOtherServices = count;
+        });
+
+        return services;
+    }
+
+    private addTimesReferenced (dependencyTree: DependencyNode, dependencyName: String) {
+        let count = 0;
+
+        function traverse (node: DependencyNode) {
+            if (node.name === dependencyName) {
+                count++;
+            }
+            node.dependencies.forEach(childNode => traverse(childNode));
+        }
+
+        traverse(dependencyTree);
+
+        return count;
+    }
+
+    private hashServiceCacheObject () {
         const sha256Hash = createHash("sha256");
 
-        this.serviceFiles
-            .map(serviceFile => readFileSync(serviceFile))
-            .forEach((serviceFile:any) => {
-                sha256Hash.update(serviceFile);
-            });
+        sha256Hash.update(JSON.stringify(this.__servicesCacheObject));
 
         return sha256Hash.digest("hex");
     }

--- a/src/state/inventory.ts
+++ b/src/state/inventory.ts
@@ -10,7 +10,7 @@ import { Module } from "../model/Module.js";
 import { readServices } from "./service-reader.js";
 import { DependencyNameResolver } from "./dependency-name-resolver.js";
 import { DependencyTreeBuilder } from "./dependency-tree-builder.js";
-import DependencyNode from "../model/DependencyNode.js";
+import { DependencyNode } from "../model/DependencyGraph.js";
 
 interface InventoryCache {
   hash: string;
@@ -73,7 +73,7 @@ export class Inventory {
             });
     }
 
-    private get __servicesCacheObject (): Service[] {
+    private get servicesCacheObject (): Service[] {
         const partialServices: Partial<Service>[] = this.serviceFiles.flatMap(readServices);
         const dependencyNameResolver = new DependencyNameResolver(partialServices);
 
@@ -94,7 +94,7 @@ export class Inventory {
     }
 
     private loadServices (): Service[] {
-        const services: Service[] = this.__servicesCacheObject;
+        const services: Service[] = this.servicesCacheObject;
 
         services.forEach(dependency => {
             let count = 0;
@@ -127,7 +127,7 @@ export class Inventory {
     private hashServiceCacheObject () {
         const sha256Hash = createHash("sha256");
 
-        sha256Hash.update(JSON.stringify(this.__servicesCacheObject));
+        sha256Hash.update(JSON.stringify(this.servicesCacheObject));
 
         return sha256Hash.digest("hex");
     }

--- a/test/commands/dependency/service.spec.ts
+++ b/test/commands/dependency/service.spec.ts
@@ -1,0 +1,104 @@
+import { expect, jest } from "@jest/globals";
+import Service from "../../../src/commands/dependency/service.js";
+import { Config } from "@oclif/core";
+import DependencyTree from "../../../src/run/dependency/dependency-tree.js";
+import DependencyDiagram from "../../../src/run/dependency/dependency-diagram.js";
+
+jest.mock("../../../src/run/dependency/dependency-diagram.js", () => {
+    return jest.fn().mockImplementation(() => ({
+        createDependencyDiagrams: jest.fn()
+    }));
+});
+
+jest.mock("../../../src/run/dependency/dependency-tree.js");
+
+jest.mock("../../../src/state/inventory", () => ({
+    Inventory: function () {
+        return { services: [{ name: "A", repository: { url: "test@git.com" } }] };
+    }
+}));
+
+const dependencyTreeMock = {
+    generateTree: jest.fn(),
+    generateFlatTree: jest.fn()
+};
+
+const dependencyDiagramMock = {
+    createDependencyDiagrams: jest.fn()
+};
+
+describe("Service Command", () => {
+    let serviceCmd: Service;
+    let mockConfig: Config;
+    let logMock;
+    let errorMock;
+
+    let parseMock;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        // @ts-expect-error
+        mockConfig = { root: "./", configDir: "./config", cacheDir: "./cache" };
+
+        // @ts-expect-error
+        DependencyTree.mockReturnValue(dependencyTreeMock);
+        // @ts-expect-error
+        DependencyDiagram.mockReturnValue(dependencyDiagramMock);
+
+        serviceCmd = new Service(["A"], mockConfig);
+
+        logMock = jest.spyOn(serviceCmd, "log");
+        errorMock = jest.spyOn(serviceCmd, "error");
+
+        // @ts-expect-error
+        parseMock = jest.spyOn(serviceCmd, "parse");
+    });
+
+    it("calls generateTree for type 'tree'", async () => {
+        (serviceCmd as any).flagValues = { type: "tree" };
+
+        await (serviceCmd as any).handleValidService("A");
+        expect(dependencyTreeMock.generateTree).toHaveBeenCalledWith("A");
+    });
+
+    it("calls generateFlatTree for type 'flattree'", async () => {
+        (serviceCmd as any).flagValues = { type: "flattree" };
+        await (serviceCmd as any).handleValidService("A");
+        expect(dependencyTreeMock.generateFlatTree).toHaveBeenCalledWith("A");
+    });
+
+    it("calls createDependencyDiagrams for type 'diagram'", async () => {
+        (serviceCmd as any).flagValues = { type: "diagram" };
+        await (serviceCmd as any).handleValidService("A");
+        expect(dependencyDiagramMock.createDependencyDiagrams).toHaveBeenCalledWith("A");
+    });
+
+    it("calls error for invalid type", async () => {
+        (serviceCmd as any).flagValues = { type: "invalid" };
+        (serviceCmd as any).error = jest.fn();
+        await (serviceCmd as any).handleValidService("A");
+        expect((serviceCmd as any).error).toHaveBeenCalledWith("'invalid' is not a valid value");
+    });
+
+    it("does nothing if flagValues is undefined", async () => {
+        (serviceCmd as any).flagValues = undefined;
+        await (serviceCmd as any).handleValidService("A");
+        expect(dependencyTreeMock.generateTree).not.toHaveBeenCalled();
+        expect(dependencyTreeMock.generateFlatTree).not.toHaveBeenCalled();
+        expect(dependencyDiagramMock.createDependencyDiagrams).not.toHaveBeenCalled();
+        expect(serviceCmd.error).not.toHaveBeenCalled();
+    });
+
+    it("parseArgumentsAndFlags delegates to parse", async () => {
+        parseMock.mockResolvedValue(
+            {
+                argv: ["A"],
+                flags: { type: "tree" }
+            }
+        );
+        const result = await (serviceCmd as any).parseArgumentsAndFlags();
+        expect(result).toEqual({ argv: ["A"], flags: { type: "tree" } });
+        expect((serviceCmd as any).parse).toHaveBeenCalledWith(Service);
+    });
+});

--- a/test/commands/dependency/system.spec.ts
+++ b/test/commands/dependency/system.spec.ts
@@ -1,0 +1,54 @@
+import { expect, jest } from "@jest/globals";
+import System from "../../../src/commands/dependency/system.js";
+
+import DependencyDiagram from "../../../src/run/dependency/dependency-diagram.js";
+import { DependencyObjectType } from "../../../src/model/DependencyGraph.js";
+import { modules, services } from "../../utils/data.js";
+import { Inventory } from "../../../src/state/inventory.js";
+
+jest.mock("../../../src/state/inventory.js");
+jest.mock("../../../src/run/dependency/dependency-diagram.js", () => {
+    return jest.fn().mockImplementation(() => ({
+        createSystemDiagram: jest.fn()
+    }));
+});
+
+const inventoryMock = {
+    services,
+    modules
+} as Inventory;
+
+const dependencyDiagramMock = {
+    createSystemDiagram: jest.fn()
+};
+
+describe("System Command", () => {
+    let cmd: System;
+    let mockConfig: any;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        mockConfig = { cacheDir: "/mock/cache" };
+        // @ts-expect-error
+        Inventory.mockReturnValue(inventoryMock);
+
+        // @ts-expect-error
+        DependencyDiagram.mockReturnValue(dependencyDiagramMock);
+
+        cmd = new System([], mockConfig);
+        cmd.log = jest.fn();
+    });
+
+    it("constructs with correct DependencyDiagram type", () => {
+        expect((cmd as any).diagram).toBeDefined();
+        expect(DependencyDiagram).toHaveBeenCalledWith(
+            DependencyObjectType.SYSTEM,
+            expect.any(Function)
+        );
+    });
+
+    it("run calls createSystemDiagram with inventory", async () => {
+        await cmd.run();
+        expect(dependencyDiagramMock.createSystemDiagram).toHaveBeenCalledWith(inventoryMock);
+    });
+});

--- a/test/commands/development/enable.spec.ts
+++ b/test/commands/development/enable.spec.ts
@@ -198,7 +198,7 @@ describe("development enable", () => {
             gitCloneMock.mockResolvedValue(undefined);
 
             await expect(developmentEnable.run()).rejects.toEqual(new Error(
-                `Service "${serviceName}" does not have repository defined`
+                `Service "${serviceName}" does not have a git repository url defined`
             ));
         });
     }

--- a/test/helpers/git.spec.ts
+++ b/test/helpers/git.spec.ts
@@ -1,5 +1,5 @@
 import { expect, jest } from "@jest/globals";
-import { cloneRepo, updateRepo, checkoutNewBranch, addToStage, commit, push, checkoutExistingBranch, getCommitCountAheadOfRemote } from "../../src/helpers/git";
+import { cloneRepo, updateRepo, checkoutNewBranch, addToStage, commit, push, checkoutExistingBranch, getCommitCountAheadOfRemote, gitSshToHttps } from "../../src/helpers/git";
 import { simpleGit } from "simple-git";
 
 const gitCloneMock = jest.fn();
@@ -196,5 +196,23 @@ describe("getCommitCountAheadOfRemote", () => {
 
         expect(gitRaw).toBeCalledWith(["rev-list", "HEAD..@{upstream}", "--count"]);
         expect(gitRaw).toHaveReturnedWith(0);
+    });
+});
+
+describe("gitSshToHttps", () => {
+    it("converts SSH URL to HTTPS", () => {
+        const sshUrl = "git@github.com:user/repo.git";
+        const httpsUrl = gitSshToHttps(sshUrl);
+        expect(httpsUrl).toBe("https://github.com/user/repo");
+    });
+
+    it("converts SSH URL without .git to HTTPS", () => {
+        const sshUrl = "git@github.com:user/repo";
+        const httpsUrl = gitSshToHttps(sshUrl);
+        expect(httpsUrl).toBe("https://github.com/user/repo");
+    });
+
+    it("throws error for invalid SSH URL", () => {
+        expect(() => gitSshToHttps("invalid-url")).toThrow("Invalid SSH Git URL format");
     });
 });

--- a/test/helpers/validator.spec.ts
+++ b/test/helpers/validator.spec.ts
@@ -57,7 +57,7 @@ describe("serviceValidator", () => {
 
         serviceValidatorUnderTest("service-three");
 
-        expect(errorMock).toHaveBeenCalledWith("Service \"service-three\" does not have repository defined");
+        expect(errorMock).toHaveBeenCalledWith("Service \"service-three\" does not have a git repository url defined");
     });
 });
 

--- a/test/run/dependency/dependency-diagram.spec.ts
+++ b/test/run/dependency/dependency-diagram.spec.ts
@@ -1,0 +1,123 @@
+import { expect, jest } from "@jest/globals";
+import { DependencyNode, DependencyObjectType } from "../../../src/model/DependencyGraph.js";
+import DependencyDiagram from "../../../src/run/dependency/dependency-diagram.js";
+import { GraphBuilder, GraphOptions } from "../../../src/run/graph-builder.js";
+
+import Service from "../../../src/model/Service.js";
+import { Inventory } from "../../../src/state/inventory.js";
+import { ServiceFinder } from "../../../src/run/dependency/AbstractDependencyGraph.js";
+import fs from "fs";
+import { graphviz } from "node-graphviz";
+import { modules, services } from "../../utils/data.js";
+
+type ServiceGitDescriptionAndOwner = Service & {
+    gitDescription: string;
+    teamOwner: string;
+};
+
+jest.mock("node-graphviz");
+jest.mock("../../../src/state/inventory.js");
+jest.mock("open", () => jest.fn());
+
+const mockService = (name: string, dependencies: DependencyNode[] = []) => ({
+    name,
+    dependencyTree: { name, dependencies },
+    gitDescription: "desc",
+    teamOwner: "owner",
+    numberOfDependencies: dependencies.length,
+    timesUsedByOtherServices: 1
+});
+
+const inventoryMock = {
+    services,
+    modules
+} as Inventory;
+
+// Helper to build DependencyNode
+function node (name: string, dependencies: DependencyNode[] = []): DependencyNode {
+    return { name, dependencies };
+}
+
+describe("DependencyDiagram", () => {
+    let diagram: DependencyDiagram;
+    const mockLogger = jest.fn();
+    const mockServiceFinder = jest.fn() as jest.Mock<ServiceFinder>;
+    const writeFileSyncSpy = jest.spyOn(fs, "writeFileSync");
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        // @ts-expect-error
+        Inventory.mockReturnValue(inventoryMock);
+
+        mockServiceFinder.mockReturnValue(
+            mockService("A", [node("B")]) as ServiceGitDescriptionAndOwner
+        );
+        diagram = new DependencyDiagram(DependencyObjectType.SERVICE, mockLogger, mockServiceFinder);
+        writeFileSyncSpy.mockReturnValue(undefined);
+    });
+
+    it("logs and generates diagram for a service", async () => {
+
+        (graphviz.dot as jest.Mock).mockImplementation(() => Promise.resolve("<svg>dot</svg>"));
+
+        await diagram.createDependencyDiagrams("A");
+
+        expect(mockLogger).toHaveBeenCalledWith(expect.stringContaining("Creating dependency diagram for service: A"));
+        expect(writeFileSyncSpy).toHaveBeenCalledWith(
+            expect.stringContaining("A-dependency_diagram.svg"),
+            "<svg>dot</svg>"
+        );
+        expect(require("open")).toHaveBeenCalled();
+    });
+
+    it("does not log or generate diagram if service not found", async () => {
+        mockServiceFinder.mockReturnValue(undefined);
+        const diagram = new DependencyDiagram(DependencyObjectType.SERVICE, mockLogger, mockServiceFinder);
+
+        await diagram.createDependencyDiagrams("Unknown");
+
+        expect(mockLogger).not.toHaveBeenCalledWith(expect.stringContaining("Creating dependency diagram"));
+        expect(writeFileSyncSpy).not.toHaveBeenCalled();
+    });
+
+    it("logs and generates system diagram from the inventory", async () => {
+
+        (graphviz.fdp as jest.Mock).mockImplementation(() => Promise.resolve("<svg>fdp</svg>"));
+
+        diagram = new DependencyDiagram(DependencyObjectType.SYSTEM, mockLogger);
+
+        await diagram.createSystemDiagram(inventoryMock);
+
+        expect(mockLogger).toHaveBeenCalledWith("Creating system dependency diagram");
+        expect(writeFileSyncSpy).toHaveBeenCalledWith(
+            expect.stringContaining("system-dependency_diagram.svg"),
+            "<svg>fdp</svg>"
+        );
+        expect(require("open")).toHaveBeenCalled();
+    });
+
+    it("handleTraverse adds nodes and edges to builder", () => {
+        const builder = new GraphBuilder("Test", {} as GraphOptions);
+        builder.addNode = jest.fn();
+        builder.addEdge = jest.fn();
+
+        const service = mockService("A", [node("B")]) as ServiceGitDescriptionAndOwner;
+
+        const seenEdges = new Set<string>();
+        diagram.handleTraverse(service.dependencyTree as DependencyNode, builder, seenEdges);
+
+        expect(builder.addNode).toHaveBeenCalledWith("A", "A", expect.any(String), "#");
+        expect(builder.addEdge).toHaveBeenCalledWith("A", "B");
+    });
+
+    it("generateAndOpenDiagram logs error on failure", async () => {
+
+        const error = new Error("fail");
+        (graphviz.dot as jest.Mock).mockImplementation(() => Promise.reject(error));
+
+        await (diagram as any).generateAndOpenDiagram("lines", "path.svg", "dot");
+
+        expect(mockLogger).toHaveBeenCalledWith(expect.stringContaining("An error occurred"));
+    });
+});

--- a/test/run/dependency/dependency-tree.spec.ts
+++ b/test/run/dependency/dependency-tree.spec.ts
@@ -1,0 +1,118 @@
+import DependencyTree from "../../../src/run/dependency/dependency-tree";
+import { DependencyNode } from "../../../src/model/DependencyGraph";
+import { expect, jest } from "@jest/globals";
+import { ServiceFinder } from "../../../src/run/dependency/AbstractDependencyGraph";
+import Service from "../../../src/model/Service";
+
+// Mocks
+jest.mock("../../../src/helpers/colouriser.js", () => ({
+    simpleColouriser: (str: string, _colour: string) => str
+}));
+
+// Helper to build DependencyNode
+function node (name: string, dependencies: DependencyNode[] = []): DependencyNode {
+    return { name, dependencies };
+}
+
+describe("DependencyTree", () => {
+    let logger: jest.Mock;
+    let serviceFinder: jest.Mock<ServiceFinder>;
+
+    beforeEach(() => {
+        logger = jest.fn();
+        serviceFinder = jest.fn() as jest.Mock<ServiceFinder>;
+    });
+
+    it("should log a single node tree correctly with generateTree", () => {
+        const serviceName = "ServiceA";
+        serviceFinder.mockReturnValue({
+            dependencyTree: node(serviceName)
+        } as Service);
+        const tree = new DependencyTree(logger, serviceFinder);
+        tree.generateTree(serviceName);
+
+        expect(logger).toHaveBeenCalledWith(expect.stringContaining("└── ServiceA"));
+    });
+
+    it("should log a multi-level tree with correct formatting", () => {
+        const serviceName = "Root";
+        const depTree = node(serviceName, [
+            node("Dep1", [
+                node("SubDep1"),
+                node("SubDep2")
+            ]),
+            node("Dep2")
+        ]);
+        serviceFinder.mockReturnValue({ dependencyTree: depTree } as Service);
+        const tree = new DependencyTree(logger, serviceFinder);
+        tree.generateTree(serviceName);
+
+        const output = logger.mock.calls[0][0];
+        expect(output).toContain("└── Root");
+        expect(output).toContain("├── Dep1");
+        expect(output).toContain("│   ├── SubDep1");
+        expect(output).toContain("│   └── SubDep2");
+        expect(output).toContain("└── Dep2");
+    });
+
+    it("should mark shared dependencies as (shared dependency)", () => {
+        const serviceName = "Root";
+        const shared = node("Shared");
+        const depTree = node(serviceName, [
+            node("Dep1", [shared]),
+            node("Dep2", [shared])
+        ]);
+        serviceFinder.mockReturnValue({ dependencyTree: depTree }as Service);
+        const tree = new DependencyTree(logger, serviceFinder);
+        tree.generateTree(serviceName);
+
+        const output = logger.mock.calls[0][0];
+        expect(output).toContain("Shared (shared dependency)");
+    });
+
+    it("should log a flat tree for a single node", () => {
+        const serviceName = "Solo";
+        serviceFinder.mockReturnValue({ dependencyTree: node(serviceName) } as Service);
+        const tree = new DependencyTree(logger, serviceFinder);
+        tree.generateFlatTree(serviceName);
+
+        expect(logger).toHaveBeenCalledWith("Solo");
+    });
+
+    it("should log a flat tree for multi-level tree with deduplication", () => {
+        const serviceName = "Root";
+        const shared = node("Shared");
+        const depTree = node(serviceName, [
+            node("Dep1", [shared]),
+            node("Dep2", [shared])
+        ]);
+        serviceFinder.mockReturnValue({ dependencyTree: depTree } as Service);
+        const tree = new DependencyTree(logger, serviceFinder);
+        tree.generateFlatTree(serviceName);
+
+        const output:any = logger.mock.calls[0][0];
+        // Should contain all nodes, but only one "Shared"
+        expect(output).toContain("Root");
+        expect(output).toContain("Dep1");
+        expect(output).toContain("Dep2");
+        expect(output.match(/Shared/g)?.length).toBe(1);
+    });
+
+    it("should not log if service is not found", () => {
+        serviceFinder.mockReturnValue(undefined);
+        const tree = new DependencyTree(logger, serviceFinder);
+        tree.generateTree("UnknownService");
+        tree.generateFlatTree("UnknownService");
+        expect(logger).not.toHaveBeenCalled();
+    });
+
+    it("should handle empty dependency tree gracefully", () => {
+        serviceFinder.mockReturnValue({ dependencyTree: undefined } as Service);
+        const tree = new DependencyTree(logger, serviceFinder);
+        tree.generateTree("EmptyService");
+        tree.generateFlatTree("EmptyService");
+        // Should log nothing or empty string
+        expect(logger).toHaveBeenCalledWith("");
+        expect(logger).toHaveBeenCalledWith("");
+    });
+});

--- a/test/run/graph-builder.spec.ts
+++ b/test/run/graph-builder.spec.ts
@@ -21,7 +21,7 @@ describe("GraphBuilder", () => {
         graphBuilder.addNode("A", "LabelA", "TooltipA", "#ff0000");
         expect((graphBuilder as any).lines).toEqual(expect.arrayContaining([expect.stringContaining("A")]));
         expect((graphBuilder as any).lines).toEqual(expect.arrayContaining([
-            expect.stringContaining("label=\"Label\""),
+            expect.stringContaining("label=\"LabelA\""),
             expect.stringContaining("tooltip=\"TooltipA\""),
             expect.stringContaining("href=\"#ff0000\"")
         ]));

--- a/test/run/graph-builder.spec.ts
+++ b/test/run/graph-builder.spec.ts
@@ -41,7 +41,7 @@ describe("GraphBuilder", () => {
         expect(dot).toEqual(expect.stringContaining("digraph TestDiagram {"));
         expect(dot).toEqual(expect.stringContaining("graph [rankdir=TB, ranksep=5]"));
         expect(dot).toEqual(expect.stringContaining("node [shape=box, style=filled, color=lightblue2]"));
-        expect(dot).toEqual(expect.stringContaining("\"A\" [label=\"LabelA\", tooltip=\"TooltipA\", href=\"#ff0000\"]"));
+        expect(dot).toEqual(expect.stringContaining("\"A\" [label=\"LabelA\", tooltip=\"TooltipA\", href=\"#ff0000\", target=\"_blank\"]"));
         expect(dot).toEqual(expect.stringContaining("\"A\" -> \"B\""));
     });
 

--- a/test/run/graph-builder.spec.ts
+++ b/test/run/graph-builder.spec.ts
@@ -1,0 +1,54 @@
+import { expect, jest } from "@jest/globals";
+import { GraphBuilder } from "../../src/run/graph-builder.js";
+
+describe("GraphBuilder", () => {
+
+    let graphBuilder: GraphBuilder;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        graphBuilder = new GraphBuilder("TestDiagram", {
+            layout: "dot", rankdir: "TB", ranksep: 5
+        });
+    });
+    it("initializes with diagram name and options", () => {
+        expect((graphBuilder as any).diagramName).toBe("TestDiagram");
+        expect((graphBuilder as any).options.layout).toBe("dot");
+        expect((graphBuilder as any).options.rankdir).toBe("TB");
+    });
+
+    it("adds nodes with label and tooltip", () => {
+        graphBuilder.addNode("A", "LabelA", "TooltipA", "#ff0000");
+        expect((graphBuilder as any).lines).toEqual(expect.arrayContaining([expect.stringContaining("A")]));
+        expect((graphBuilder as any).lines).toEqual(expect.arrayContaining([
+            expect.stringContaining("label=\"Label\""),
+            expect.stringContaining("tooltip=\"TooltipA\""),
+            expect.stringContaining("href=\"#ff0000\"")
+        ]));
+    });
+
+    it("adds edges between nodes", () => {
+        graphBuilder.addEdge("A", "B");
+        const edgeLine = (graphBuilder as any).lines.find(line => line.includes("->"));
+        expect(edgeLine).toEqual(expect.stringContaining("A"));
+        expect(edgeLine).toEqual(expect.stringContaining("B"));
+    });
+
+    it("builds DOT output with nodes and edges", () => {
+        graphBuilder.addNode("A", "LabelA", "TooltipA", "#ff0000");
+        graphBuilder.addEdge("A", "B");
+        const dot = graphBuilder.build();
+        expect(dot).toEqual(expect.stringContaining("digraph TestDiagram {"));
+        expect(dot).toEqual(expect.stringContaining("graph [rankdir=TB, ranksep=5]"));
+        expect(dot).toEqual(expect.stringContaining("node [shape=box, style=filled, color=lightblue2]"));
+        expect(dot).toEqual(expect.stringContaining("\"A\" [label=\"LabelA\", tooltip=\"TooltipA\", href=\"#ff0000\"]"));
+        expect(dot).toEqual(expect.stringContaining("\"A\" -> \"B\""));
+    });
+
+    it("handles empty graph with no nodes or edges", () => {
+        const dot = graphBuilder.build();
+        expect(dot).toEqual(expect.stringContaining("digraph TestDiagram {"));
+        expect(dot).toEqual(expect.stringContaining("graph [rankdir=TB, ranksep=5]"));
+        expect(dot).toEqual(expect.stringContaining("node [shape=box, style=filled, color=lightblue2]"));
+    });
+});

--- a/test/state/__snapshots__/inventory.spec.ts.snap
+++ b/test/state/__snapshots__/inventory.spec.ts.snap
@@ -4,6 +4,10 @@ exports[`Inventory services returns services with all dependencies 1`] = `
 [
   {
     "builder": "",
+    "dependencyTree": {
+      "dependencies": [],
+      "name": "mongo",
+    },
     "dependsOn": [],
     "description": "primary database storing Companies House data",
     "metadata": {
@@ -11,11 +15,22 @@ exports[`Inventory services returns services with all dependencies 1`] = `
     },
     "module": "infrastructure",
     "name": "mongo",
+    "numberOfDependencies": 0,
     "repository": null,
     "source": "inventory/services/infrastructure/mongo.docker-compose.yaml",
+    "timesUsedByOtherServices": 15,
   },
   {
     "builder": "java",
+    "dependencyTree": {
+      "dependencies": [
+        {
+          "dependencies": [],
+          "name": "mongo",
+        },
+      ],
+      "name": "service-one",
+    },
     "dependsOn": [
       "mongo",
     ],
@@ -26,14 +41,34 @@ exports[`Inventory services returns services with all dependencies 1`] = `
     },
     "module": "module-one",
     "name": "service-one",
+    "numberOfDependencies": 1,
     "repository": {
       "branch": null,
       "url": "git@github.com:companieshouse/service-one.git",
     },
     "source": "inventory/services/modules/module-one/service-one.docker-compose.yaml",
+    "timesUsedByOtherServices": 5,
   },
   {
     "builder": "node",
+    "dependencyTree": {
+      "dependencies": [
+        {
+          "dependencies": [],
+          "name": "mongo",
+        },
+        {
+          "dependencies": [
+            {
+              "dependencies": [],
+              "name": "mongo",
+            },
+          ],
+          "name": "service-one",
+        },
+      ],
+      "name": "service-two",
+    },
     "dependsOn": [
       "mongo",
       "service-one",
@@ -45,14 +80,52 @@ exports[`Inventory services returns services with all dependencies 1`] = `
     },
     "module": "module-one",
     "name": "service-two",
+    "numberOfDependencies": 2,
     "repository": {
       "branch": null,
       "url": "git@github.com:companieshouse/service-one.git",
     },
     "source": "inventory/services/modules/module-one/service-two.docker-compose.yaml",
+    "timesUsedByOtherServices": 3,
   },
   {
     "builder": "java",
+    "dependencyTree": {
+      "dependencies": [
+        {
+          "dependencies": [],
+          "name": "mongo",
+        },
+        {
+          "dependencies": [
+            {
+              "dependencies": [],
+              "name": "mongo",
+            },
+            {
+              "dependencies": [
+                {
+                  "dependencies": [],
+                  "name": "mongo",
+                },
+                {
+                  "dependencies": [
+                    {
+                      "dependencies": [],
+                      "name": "mongo",
+                    },
+                  ],
+                  "name": "service-one",
+                },
+              ],
+              "name": "service-two",
+            },
+          ],
+          "name": "service-three",
+        },
+      ],
+      "name": "service-four",
+    },
     "dependsOn": [
       "mongo",
       "service-three",
@@ -66,14 +139,43 @@ exports[`Inventory services returns services with all dependencies 1`] = `
     },
     "module": "module-two",
     "name": "service-four",
+    "numberOfDependencies": 4,
     "repository": {
       "branch": null,
       "url": "git@github.com:companieshouse/service-one.git",
     },
     "source": "inventory/services/modules/module-two/service-four.docker-compose.yaml",
+    "timesUsedByOtherServices": 0,
   },
   {
     "builder": "",
+    "dependencyTree": {
+      "dependencies": [
+        {
+          "dependencies": [],
+          "name": "mongo",
+        },
+        {
+          "dependencies": [
+            {
+              "dependencies": [],
+              "name": "mongo",
+            },
+            {
+              "dependencies": [
+                {
+                  "dependencies": [],
+                  "name": "mongo",
+                },
+              ],
+              "name": "service-one",
+            },
+          ],
+          "name": "service-two",
+        },
+      ],
+      "name": "service-seven",
+    },
     "dependsOn": [
       "mongo",
       "service-two",
@@ -86,14 +188,34 @@ exports[`Inventory services returns services with all dependencies 1`] = `
     },
     "module": "module-two",
     "name": "service-seven",
+    "numberOfDependencies": 3,
     "repository": {
       "branch": "feature/my-branch",
       "url": "git@github.com:companieshouse/service-one.git",
     },
     "source": "inventory/services/modules/module-two/service-seven.docker-compose.yaml",
+    "timesUsedByOtherServices": 0,
   },
   {
     "builder": "repository",
+    "dependencyTree": {
+      "dependencies": [
+        {
+          "dependencies": [],
+          "name": "mongo",
+        },
+        {
+          "dependencies": [
+            {
+              "dependencies": [],
+              "name": "mongo",
+            },
+          ],
+          "name": "service-one",
+        },
+      ],
+      "name": "service-six",
+    },
     "dependsOn": [
       "mongo",
       "service-one",
@@ -104,14 +226,43 @@ exports[`Inventory services returns services with all dependencies 1`] = `
     },
     "module": "module-two",
     "name": "service-six",
+    "numberOfDependencies": 2,
     "repository": {
       "branch": null,
       "url": "git@github.com:companieshouse/service-one.git",
     },
     "source": "inventory/services/modules/module-two/service-six.docker-compose.yaml",
+    "timesUsedByOtherServices": 0,
   },
   {
     "builder": "java",
+    "dependencyTree": {
+      "dependencies": [
+        {
+          "dependencies": [],
+          "name": "mongo",
+        },
+        {
+          "dependencies": [
+            {
+              "dependencies": [],
+              "name": "mongo",
+            },
+            {
+              "dependencies": [
+                {
+                  "dependencies": [],
+                  "name": "mongo",
+                },
+              ],
+              "name": "service-one",
+            },
+          ],
+          "name": "service-two",
+        },
+      ],
+      "name": "service-three",
+    },
     "dependsOn": [
       "mongo",
       "service-two",
@@ -123,11 +274,13 @@ exports[`Inventory services returns services with all dependencies 1`] = `
     },
     "module": "module-two",
     "name": "service-three",
+    "numberOfDependencies": 3,
     "repository": {
       "branch": null,
       "url": "git@github.com:companieshouse/service-one.git",
     },
     "source": "inventory/services/modules/module-two/service-three.docker-compose.yaml",
+    "timesUsedByOtherServices": 1,
   },
 ]
 `;

--- a/test/state/dependency-tree-builder.spec.ts
+++ b/test/state/dependency-tree-builder.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from "@jest/globals";
+import { DependencyTreeBuilder } from "../../src/state/dependency-tree-builder.js";
+
+describe("DependencyTreeBuilder", () => {
+    const services = [
+        { name: "A", dependsOn: ["B", "C"] },
+        { name: "B", dependsOn: ["D"] },
+        { name: "C", dependsOn: [] },
+        { name: "D", dependsOn: [] }
+    ];
+
+    it("builds tree for direct and transitive dependencies", () => {
+        const builder = new DependencyTreeBuilder(services);
+        const tree = builder.dependencyTree("A");
+
+        expect(tree).toEqual({
+            name: "A",
+            dependencies: [
+                {
+                    name: "B",
+                    dependencies: [
+                        { name: "D", dependencies: [] }
+                    ]
+                },
+                {
+                    name: "C",
+                    dependencies: []
+                }
+            ]
+        });
+    });
+    it("returns node with no dependencies if service not found", () => {
+        const builder = new DependencyTreeBuilder(services);
+        const tree = builder.dependencyTree("X");
+        expect(tree).toEqual({ name: "X", dependencies: [] });
+    });
+
+    it("handles cyclic dependencies gracefully", () => {
+        const cyclicServices = [
+            { name: "A", dependsOn: ["B"] },
+            { name: "B", dependsOn: ["A"] }
+        ];
+        const builder = new DependencyTreeBuilder(cyclicServices);
+        const tree = builder.dependencyTree("A");
+        expect(tree).toEqual({
+            name: "A",
+            dependencies: [
+                {
+                    name: "B",
+                    dependencies: [
+                        { name: "A", dependencies: [] }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it("returns node with no dependencies if dependsOn is missing", () => {
+        const incompleteServices = [
+            { name: "A" }
+        ];
+        const builder = new DependencyTreeBuilder(incompleteServices);
+        const tree = builder.dependencyTree("A");
+        expect(tree).toEqual({ name: "A", dependencies: [] });
+    });
+});


### PR DESCRIPTION
This feature enables users to view the dependencies and their relationships to a specific service, along with Git metadata such as repository descriptions and team ownership (where available). The `service mode` provides insights into how a given service connects to others and supports three visual output formats: `diagram`, `tree`, and `flattree`. In contrast, the `system mode` presents a holistic view of the interconnectedness across all services within `docker-chs-development`, and its output is available as a diagram only.

This feature is based off the [Information Topic](https://github.com/companieshouse/chs-dev/pull/129) feature by **Dan Toulcher**.


Each dependency node in the diagram output includes a link to its Git repository, allowing users to quickly navigate to the corresponding repo for more details.

COMMANDS
- `chs-dev dependency service serviceName --type=<value>`
Generates a dependency diagram / tree for the specified service(s), where `type`= 'diagram' | 'tree' | 'flattree'.
-  `chs-dev dependency system`
Generates a system dependency Diagram.

Screenshots
**Diagram**
<img width="1166" height="785" alt="Screenshot 2025-08-04 at 22 50 48" src="https://github.com/user-attachments/assets/831389bf-eab5-4538-b65c-0c73eb65a478" />
**Tree**
<img width="959" height="1600" alt="Screenshot 2025-08-04 at 22 51 33" src="https://github.com/user-attachments/assets/f106f055-2887-485d-95d6-71f7e0345113" />
**Flattree**
<img width="492" height="641" alt="Screenshot 2025-08-04 at 22 52 06" src="https://github.com/user-attachments/assets/cb4bfc5c-5dec-4439-a49f-d0735aa2598e" />

