### PR TITLE
Dvop 4480 env flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,11 +773,12 @@ Brings up the docker-chs-development environment
 
 ```
 USAGE
-  $ chs-dev up [--otel] [--no-otel]
+  $ chs-dev up [--otel] [--no-otel] [--env]
 
 FLAGS
-  --no-otel  Disable OpenTelemetry for tracing
-  --otel     Enable OpenTelemetry for tracing
+  --no-otel     Disable OpenTelemetry for tracing
+  --otel        Enable OpenTelemetry for tracing
+  --env         Set to run versions of images in cidev, staging or live. Not setting will build from latest
 
 DESCRIPTION
   Brings up the docker-chs-development environment
@@ -788,6 +789,8 @@ EXAMPLES
   $ chs-dev up --otel
 
   $ chs-dev up --no-otel
+
+  $ chs-dev up --env cidev
 ```
 
 DOCUMENTATION

--- a/README.md
+++ b/README.md
@@ -773,12 +773,13 @@ Brings up the docker-chs-development environment
 
 ```
 USAGE
-  $ chs-dev up [--otel] [--no-otel] [--env]
+  $ chs-dev up [--otel] [--no-otel] [--env cidev|staging|live]
 
 FLAGS
-  --no-otel     Disable OpenTelemetry for tracing
-  --otel        Enable OpenTelemetry for tracing
-  --env         Set to run versions of images in cidev, staging or live. Not setting will build from latest
+  --env=<option>  Set the environment to mimic, this will determine which versions of images are pulled
+                  <options: cidev|staging|live>
+  --no-otel       Disable OpenTelemetry for tracing
+  --otel          Enable OpenTelemetry for tracing
 
 DESCRIPTION
   Brings up the docker-chs-development environment

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -39,13 +39,19 @@ export default class Up extends Command {
         "no-otel": Flags.boolean({
             aliases: ["no-otel"],
             description: "Disable OpenTelemetry for tracing"
+        }),
+        env: Flags.string({
+            aliases: ["env"],
+            description: "Set the environment to mimic, this will determine which versions of images are pulled",
+            options: ["cidev", "staging", "live"]
         })
     };
 
     static examples = [
         "$ chs-dev up",
         "$ chs-dev up --otel",
-        "$ chs-dev up --no-otel"
+        "$ chs-dev up --no-otel",
+        "$ chs-dev up --env cidev"
     ];
 
     private readonly dependencyCache: DependencyCache;
@@ -57,6 +63,7 @@ export default class Up extends Command {
     private readonly permanentRepositories: PermanentRepositories;
     private readonly otelGenerator: OtelGenerator;
     private servicesBuildContext!: ServicesBuildContext;
+    private tagMap: Record<string, string>;
 
     constructor (argv: string[], config: Config) {
         super(argv, config);
@@ -75,6 +82,11 @@ export default class Up extends Command {
         this.inventory = new Inventory(this.chsDevConfig.projectPath, config.cacheDir);
         this.permanentRepositories = new PermanentRepositories(this.chsDevConfig, this.inventory);
         this.otelGenerator = new OtelGenerator(this.chsDevConfig.projectPath);
+        this.tagMap = {
+            cidev: "current-development-cidev",
+            staging: "current-staging-staging",
+            live: "current-live-live"
+        };
     }
 
     async run (): Promise<any> {
@@ -102,6 +114,11 @@ export default class Up extends Command {
             });
         }
 
+        let extraArgs: string[] = [];
+        if (flags.env) {
+            extraArgs = ["-e", `TAG=${this.tagMap[flags.env]}`];
+        }
+
         this.otelGenerator.modifyGeneratedDockerCompose(flags);
 
         if (this.hasServicesInDevelopmentMode) {
@@ -126,7 +143,7 @@ export default class Up extends Command {
 
         ux.action.start(`Running chs-dev environment: ${basename(this.chsDevConfig.projectPath)}`);
         try {
-            await this.dockerCompose.up();
+            await this.dockerCompose.up(extraArgs);
             await this.handleDevelopmentMode();
 
         } catch (error) {

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -114,9 +114,11 @@ export default class Up extends Command {
             });
         }
 
-        let extraArgs: string[] = [];
         if (flags.env) {
-            extraArgs = ["-e", `TAG=${this.tagMap[flags.env]}`];
+            if (!this.chsDevConfig.dynamicEnv) {
+                this.chsDevConfig.dynamicEnv = {};
+            }
+            this.chsDevConfig.dynamicEnv.TAG = this.tagMap[flags.env];
         }
 
         this.otelGenerator.modifyGeneratedDockerCompose(flags);
@@ -143,7 +145,7 @@ export default class Up extends Command {
 
         ux.action.start(`Running chs-dev environment: ${basename(this.chsDevConfig.projectPath)}`);
         try {
-            await this.dockerCompose.up(extraArgs);
+            await this.dockerCompose.up();
             await this.handleDevelopmentMode();
 
         } catch (error) {

--- a/src/model/Config.ts
+++ b/src/model/Config.ts
@@ -1,5 +1,5 @@
 /**
- * Represents project configuration defining project related properties for
+ * Represents configuration defining project related properties for
  * customising the behaviours of chs-dev
  */
 export type Config = {
@@ -46,6 +46,12 @@ export type Config = {
      * specifies the application version
      */
     readonly chsDevVersion?: string;
+
+    /**
+     * For non-static environment config created in chs-dev run
+     * on behalf of user
+     */
+    dynamicEnv?: Record<string, string>
 
 }
 

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -99,8 +99,8 @@ export class DockerCompose {
             : undefined;
     }
 
-    up (extraArgs: string[] = [], signal?: AbortSignal): Promise<void> {
-        return this.runDockerCompose(["up", "-d", "--remove-orphans", ...extraArgs],
+    up (signal?: AbortSignal): Promise<void> {
+        return this.runDockerCompose(["up", "-d", "--remove-orphans"],
             this.createStatusMatchLogHandler(CONTAINER_STARTED_HEALTHY_STATUS_PATTERN, runStatusColouriser),
             signal
         );
@@ -228,7 +228,10 @@ export class DockerCompose {
 
     private async runDockerCompose (composeArgs: string[], logHandler: LogHandler, signal?: AbortSignal): Promise<void> {
         // Spawn docker compose process
-        const dockerComposeEnv = this.config.env;
+        const dockerComposeEnv = {
+            ...this.config.env,
+            ...this.config.dynamicEnv
+        };
         const spawnOptions: {
             cwd: string,
             signal?: AbortSignal,

--- a/src/run/docker-compose.ts
+++ b/src/run/docker-compose.ts
@@ -99,8 +99,8 @@ export class DockerCompose {
             : undefined;
     }
 
-    up (signal?: AbortSignal): Promise<void> {
-        return this.runDockerCompose(["up", "-d", "--remove-orphans"],
+    up (extraArgs: string[] = [], signal?: AbortSignal): Promise<void> {
+        return this.runDockerCompose(["up", "-d", "--remove-orphans", ...extraArgs],
             this.createStatusMatchLogHandler(CONTAINER_STARTED_HEALTHY_STATUS_PATTERN, runStatusColouriser),
             signal
         );

--- a/test/commands/up.spec.ts
+++ b/test/commands/up.spec.ts
@@ -1,6 +1,7 @@
 import { expect, jest } from "@jest/globals";
 import Up from "../../src/commands/up";
 import { Config } from "@oclif/core";
+import { Config as DockerConfig } from "../../src/model/Config";
 import { State } from "../../src/model/State";
 import { services, modules } from "../utils/data";
 import { StateManager } from "../../src/state/state-manager";
@@ -169,7 +170,7 @@ describe("Up command", () => {
         expect(otelGeneratorMock.modifyGeneratedDockerCompose).toHaveBeenCalledWith(flagsMock);
     });
 
-    it("should call up with env flag", async () => {
+    it("should set dynamicEnv with env flag", async () => {
         parseMock.mockResolvedValueOnce({
             flags: {
                 otel: false,
@@ -179,7 +180,10 @@ describe("Up command", () => {
         });
         await up.run();
 
-        expect(dockerComposeMock.up).toBeCalledWith(["-e", `TAG=current-development-cidev`]);
+        expect(dockerComposeMock.up).toBeCalled();
+        const dockerComposeClassMock = DockerCompose as jest.MockedClass<typeof DockerCompose>;
+        const dockerConfig: DockerConfig = dockerComposeClassMock.mock.calls[0][0];
+        expect(dockerConfig.dynamicEnv?.TAG).toBe("current-development-cidev");
     });
 
     it("should not call developmentMode start when no services in dev or if dev services builder are neither node nor nginx", async () => {

--- a/test/commands/up.spec.ts
+++ b/test/commands/up.spec.ts
@@ -169,6 +169,19 @@ describe("Up command", () => {
         expect(otelGeneratorMock.modifyGeneratedDockerCompose).toHaveBeenCalledWith(flagsMock);
     });
 
+    it("should call up with env flag", async () => {
+        parseMock.mockResolvedValueOnce({
+            flags: {
+                otel: false,
+                "no-otel": false,
+                env: "cidev"
+            }
+        });
+        await up.run();
+
+        expect(dockerComposeMock.up).toBeCalledWith(["-e", `TAG=current-development-cidev`]);
+    });
+
     it("should not call developmentMode start when no services in dev or if dev services builder are neither node nor nginx", async () => {
         await up.run();
 

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -383,7 +383,7 @@ describe("DockerCompose", () => {
             existsSyncMock.mockReturnValue(true);
         });
 
-        it("executes docker compose down", async () => {
+        it("executes docker compose up", async () => {
             await dockerCompose.up();
 
             const expectedSpawnOptions = {
@@ -405,6 +405,33 @@ describe("DockerCompose", () => {
                 "up",
                 "-d",
                 "--remove-orphans"
+            ], expectedSpawnOptions);
+        });
+
+        it("executes docker compose up with extraArgs", async () => {
+            await dockerCompose.up(["-e", `TAG=current-development-cidev`]);
+
+            const expectedSpawnOptions = {
+                logHandler: { handle: mockPatternMatchingHandle },
+                spawnOptions: {
+                    cwd: config.projectPath,
+                    env: {
+                        ...(process.env),
+                        SSH_PRIVATE_KEY: sshPrivateKey,
+                        ANOTHER_VALUE: "another-value",
+                        ...mockAwsCredentialsObject
+                    }
+                },
+                acceptableExitCodes: [0, 130]
+            };
+
+            expect(spawnMock).toHaveBeenCalledWith("docker", [
+                "compose",
+                "up",
+                "-d",
+                "--remove-orphans",
+                "-e",
+                "TAG=current-development-cidev"
             ], expectedSpawnOptions);
         });
 

--- a/test/run/docker-compose.spec.ts
+++ b/test/run/docker-compose.spec.ts
@@ -408,8 +408,20 @@ describe("DockerCompose", () => {
             ], expectedSpawnOptions);
         });
 
-        it("executes docker compose up with extraArgs", async () => {
-            await dockerCompose.up(["-e", `TAG=current-development-cidev`]);
+        it("executes docker compose up with dynamicEnv config", async () => {
+            const configPlusDynamicEnv = {
+                projectPath: "./",
+                projectName: "project",
+                env: {
+                    sshPrivateKey: "SSH_PRIVATE_KEY"
+                },
+                dynamicEnv: {
+                    TAG: "current-development-cidev"
+                }
+            };
+
+            const dockerComposePlusDynamicEnv = new DockerCompose(configPlusDynamicEnv, logger);
+            await dockerComposePlusDynamicEnv.up();
 
             const expectedSpawnOptions = {
                 logHandler: { handle: mockPatternMatchingHandle },
@@ -417,9 +429,9 @@ describe("DockerCompose", () => {
                     cwd: config.projectPath,
                     env: {
                         ...(process.env),
-                        SSH_PRIVATE_KEY: sshPrivateKey,
-                        ANOTHER_VALUE: "another-value",
-                        ...mockAwsCredentialsObject
+                        ...mockAwsCredentialsObject,
+                        ...configPlusDynamicEnv.dynamicEnv,
+                        ...configPlusDynamicEnv.env
                     }
                 },
                 acceptableExitCodes: [0, 130]
@@ -429,9 +441,7 @@ describe("DockerCompose", () => {
                 "compose",
                 "up",
                 "-d",
-                "--remove-orphans",
-                "-e",
-                "TAG=current-development-cidev"
+                "--remove-orphans"
             ], expectedSpawnOptions);
         });
 


### PR DESCRIPTION
Create a dynamicEnv property in Config to allow for environment config created during chs-dev run.

Currently used to set tags to allow local environments to be spun up at versions mimicking cidev, staging and live